### PR TITLE
Use Diplomaty instead of Acrobatics for Bon Mot

### DIFF
--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -51,6 +51,6 @@ function initializeSkillActions(actor: Actor): Array<SkillAction> {
     new SkillAction('demoralize', 'Demoralize', 'itm', false, 'blind-ambition', false, actor),
     new SkillAction('shove', 'Shove', 'ath', false, 'ki-strike', false, actor),
     new SkillAction('feint', 'Feint', 'dec', true, 'delay-consequence', false, actor),
-    new SkillAction('bonMot', 'Bon Mot', 'acr', false, 'hideous-laughter', true, actor),
+    new SkillAction('bonMot', 'Bon Mot', 'dip', false, 'hideous-laughter', true, actor),
   ];
 }


### PR DESCRIPTION
Bon mot is currently set to the acrobatics skill. 

Though I certainly had my fair share of acrobatic "performances" from the party rogue that were quite distracting, so maybe this is indeed working as intended...