### PR TITLE
Add buttons to roll athletics checks with MAP

### DIFF
--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -45,11 +45,11 @@ Hooks.on('renderActorSheet', async (app: ActorSheet, html: JQuery<HTMLElement>) 
 
 function initializeSkillActions(actor: Actor): Array<SkillAction> {
   return [
-    new SkillAction('disarm', 'Disarm', 'ath', true, 'perfect-strike', false, actor),
-    new SkillAction('grapple', 'Grapple', 'ath', false, 'remove-fear', false, actor),
-    new SkillAction('trip', 'Trip', 'ath', false, 'natures-enmity', false, actor),
+    new SkillAction('disarm', 'Disarm', 'ath', true, 'perfect-strike', false, actor, { includeMap: true }),
+    new SkillAction('grapple', 'Grapple', 'ath', false, 'remove-fear', false, actor, { includeMap: true }),
+    new SkillAction('trip', 'Trip', 'ath', false, 'natures-enmity', false, actor, { includeMap: true }),
     new SkillAction('demoralize', 'Demoralize', 'itm', false, 'blind-ambition', false, actor),
-    new SkillAction('shove', 'Shove', 'ath', false, 'ki-strike', false, actor),
+    new SkillAction('shove', 'Shove', 'ath', false, 'ki-strike', false, actor, { includeMap: true }),
     new SkillAction('feint', 'Feint', 'dec', true, 'delay-consequence', false, actor),
     new SkillAction('bonMot', 'Bon Mot', 'dip', false, 'hideous-laughter', true, actor),
   ];

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -1,12 +1,22 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 
+interface SkillActionOptions {
+  includeMap: boolean;
+}
+
+interface RollOption {
+  label: string;
+  map: number;
+}
+
 export default class SkillAction {
   key: string;
   label: string;
   icon: string;
   modifier: string;
   hidden: boolean;
+  includeMap: boolean;
   actor: Actor;
 
   constructor(
@@ -17,6 +27,7 @@ export default class SkillAction {
     icon: string,
     featRequired: boolean,
     actor: Actor,
+    options: SkillActionOptions = {},
   ) {
     const skill = actor.data.data.skills[proficiencyKey];
 
@@ -28,10 +39,20 @@ export default class SkillAction {
       (skill._modifiers[1].modifier > 0 && trainingRequired) ||
       (!trainingRequired && this.hasFeat(label, featRequired));
     this.icon = 'systems/pf2e/icons/spells/' + icon + '.webp';
+    this.includeMap = options.includeMap;
   }
 
   rollSkillAction() {
     game.pf2e.actions[this.key]({ event: event });
+  }
+
+  rollOptions(): Array<RollOption> {
+    const result = [{ label: `Roll ${this.modifier}`, map: 0 }];
+    if (this.includeMap) {
+      result.push({ label: game.i18n.format('PF2E.MAPAbbreviationLabel', { penalty: -5 }), map: -5 });
+      result.push({ label: game.i18n.format('PF2E.MAPAbbreviationLabel', { penalty: -10 }), map: -10 });
+    }
+    return result;
   }
 
   hasFeat(label: string, featRequired: boolean) {

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -11,7 +11,9 @@
           <h4>{{label}} <span class="activity-icon">A</span></h4>
         </div>
         <div class="button-group tags">
-          <button id="{{key}}" type="button" class="skill-action tag variant-strike">Roll {{modifier}}</button>
+          {{#each rollOptions}}
+          <button id="{{../key}}" type="button" class="skill-action tag variant-strike" data-map="{{map}}">{{label}}</button>
+          {{/each}}
         </div>
       </div>
     </div>
@@ -21,6 +23,10 @@
 
 <script>
   $('.skill-action.tag.variant-strike').click(function () {
-    game.pf2e.actions[this.id]({ event: event });
+    const modifiers = [];
+    if (this.dataset.map) {
+      modifiers.push({label: game.i18n.localize("PF2E.MultipleAttackPenalty"), modifier: parseInt(this.dataset.map), type: 'untyped'})
+    }
+    game.pf2e.actions[this.id]({ event: event, modifiers });
   });
 </script>


### PR DESCRIPTION
Roll functions allow a list of modifiers to apply to this roll. It's a bit hacky to just pass an object to modifiers instead of initializing `ModifierPF2E` but I don't know if there's anything similar to @league-of-foundry-developers/foundry-vtt-types for PF2E system and the only other way I can think of is copy pasting the definition from their repo.

### Screenshot

![image](https://user-images.githubusercontent.com/25230/149208674-3fdb8f7a-6a05-4115-a30c-a2abf1b5b595.png)
