### PR TITLE
Allow sending actions to chat

### DIFF
--- a/src/module/actions-index.ts
+++ b/src/module/actions-index.ts
@@ -1,0 +1,28 @@
+import { ItemPF2e } from './globals';
+
+export const ACTION_NAMES = ['Disarm', 'Grapple', 'Trip', 'Demoralize', 'Shove', 'Feint', 'Bon Mot'];
+
+export class ActionsIndex extends Map<string, ItemPF2e> {
+  private static _instance: ActionsIndex;
+
+  static get instance() {
+    if (!this._instance) this._instance = new ActionsIndex();
+    return this._instance;
+  }
+
+  private constructor() {
+    super();
+  }
+
+  async loadCompendium(packName: string) {
+    if (!(game instanceof Game)) return;
+
+    const pack = game.packs.get(packName);
+    if (!pack) return;
+
+    const actions = await pack.getDocuments({ name: { $in: ACTION_NAMES } });
+    for (const action of actions) {
+      if (action instanceof Item && action.name) this.set(action.name, action);
+    }
+  }
+}

--- a/src/module/globals.d.ts
+++ b/src/module/globals.d.ts
@@ -1,0 +1,22 @@
+import {
+  ConfiguredDocumentClass,
+  ConstructorDataType,
+} from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes';
+import { ItemData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs';
+import { Context } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/document.mjs';
+import { BaseActor } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs';
+
+export class ItemPF2e extends Item {
+  toChat(event?: JQuery.TriggeredEvent): Promise<undefined>;
+}
+
+export type ItemConstructor = new (
+  data?: ConstructorDataType<ItemData>,
+  context?: Context<InstanceType<ConfiguredDocumentClass<typeof BaseActor>>>,
+) => ItemPF2e;
+
+declare global {
+  interface DocumentClassConfig {
+    Item: typeof ItemPF2e;
+  }
+}

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -12,6 +12,7 @@ interface RollOption {
 
 export default class SkillAction {
   key: string;
+  itemName: string;
   label: string;
   icon: string;
   modifier: string;
@@ -32,6 +33,7 @@ export default class SkillAction {
     const skill = actor.data.data.skills[proficiencyKey];
 
     this.key = key;
+    this.itemName = label;
     this.actor = actor;
     this.label = game.i18n.localize(skill.label) + ': ' + label;
     this.modifier = (skill.value >= 0 ? ' +' : ' ') + skill.value;

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -5,7 +5,9 @@
   {{#each skills}} {{#if hidden}}
   <li class="item expandable ready" draggable="true">
     <div class="item-name">
-      <div class="item-image variant-strike" style="background-image: url({{icon}})"></div>
+      <div class="item-image variant-strike" data-item-label="{{ itemName }}" style="background-image: url({{icon}})">
+        <i class="fas fa-comment-alt"></i>
+      </div>
       <div class="actions-title">
         <div class="action-name">
           <h4>{{label}} <span class="activity-icon">A</span></h4>


### PR DESCRIPTION
Resolves #4. Allows clicking on action image and sends it to chat. The foundations laid here could be further used to get data directly from PF2E system, for example to determine the MAP penalties. To implement that, this PR:

* Adds `ActionsIndex` which indexes the 7 actions we support from PF2E compendium by label.
* Adds global definition of `ItemPF2e` because typescript.
* Add definition for `ItemConstructor` because otherwise typescript doesn't allow `new this.constructor()`.
* Add `itemLabel` property to `SkillAction`.
* On image click find action in `ActionsIndex` based on `itemLabel`, create a new instance with actor as the parent and send it to chat.

![image](https://user-images.githubusercontent.com/25230/149661673-8c1a93c1-a0e9-43ee-a433-d9ec3635bf28.png)
