### PR TITLE
Separate action definition from actor action ownership

### DIFF
--- a/src/module/globals.d.ts
+++ b/src/module/globals.d.ts
@@ -6,6 +6,7 @@ import { ItemData } from '@league-of-foundry-developers/foundry-vtt-types/src/fo
 import { Context } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/document.mjs';
 import { BaseActor } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs';
 import { ModifierPF2e } from './pf2e';
+import { ActorSkillAction } from './skill-actions';
 
 export interface ValuesList<T extends string = string> {
   value: T[];
@@ -36,12 +37,22 @@ export type ItemConstructor = new (
 
 type ActionFunction = (options: { event: JQuery.Event; modifiers: ModifierPF2e[] }) => void;
 
+export interface PF2eActorFlag {
+  actions: Record<string, ActorSkillAction>;
+  allVisible: boolean;
+}
+
 declare global {
   interface DocumentClassConfig {
     Item: typeof ItemPF2e;
   }
   interface DataConfig {
     Item: BaseItemSourcePF2e;
+  }
+  interface FlagConfig {
+    Actor: {
+      ['pf2e-sheet-skill-actions']: PF2eActorFlag;
+    };
   }
   interface Game {
     pf2e: { actions: Record<string, ActionFunction> };

--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -13,11 +13,13 @@
 // Import TypeScript modules
 import { registerSettings } from './settings';
 import { preloadTemplates } from './preloadTemplates';
-import SkillAction from './skill-actions';
 import { ActionsIndex } from './actions-index';
 import { ItemConstructor } from './globals';
-import { ModifierPF2e } from './pf2e';
-import { actionFromEvent, Flag } from './utils';
+import { Flag } from './utils';
+import { SkillActions } from './skill-actions-collections';
+import { SkillActionOwnerships } from './skill-actions-collections';
+
+const skillActions = new SkillActions();
 
 // Initialize module
 Hooks.once('init', async () => {
@@ -43,18 +45,18 @@ Hooks.on('renderActorSheet', async (app: ActorSheet, html: JQuery<HTMLElement>) 
 
   const tpl = 'modules/pf2e-sheet-skill-actions/templates/skill-actions.html';
 
-  const skillActions = initializeSkillActions(app.actor);
+  const actionOwnerships = new SkillActionOwnerships(skillActions, app.actor);
 
   const allVisible = Flag.get(app.actor, 'allVisible');
-  const skillData = Object.values(skillActions)
-    .map((action) => {
+  const skillData = actionOwnerships.all
+    .map((ownership) => {
       return {
-        enabled: action.enabled && (action.visible || allVisible),
-        key: action.key,
-        icon: action.icon,
-        label: action.label,
-        visible: action.visible,
-        rollOptions: action.rollOptions(),
+        enabled: ownership.visible || allVisible,
+        key: ownership.key,
+        icon: ownership.action.icon,
+        label: ownership.label,
+        rollOptions: ownership.rollOptions(),
+        visible: ownership.visible,
       };
     })
     .sort((a, b) => {
@@ -69,34 +71,22 @@ Hooks.on('renderActorSheet', async (app: ActorSheet, html: JQuery<HTMLElement>) 
   });
 
   $items.on('click', '.skill-action.tag.variant-strike', function (e) {
-    actionFromEvent(skillActions, e).rollSkillAction(e);
+    actionOwnerships.fromEvent(e)?.rollSkillAction(e);
   });
 
   $items.on('click', '.item-image', function (e) {
-    const actionItem = actionFromEvent(skillActions, e).actionItem;
-    if (!actionItem) return;
+    const pf2eItem = actionOwnerships.fromEvent(e)?.action.pf2eItem;
+    if (!pf2eItem) return;
 
-    const ownedItem = new (actionItem.constructor as ItemConstructor)(actionItem.toJSON(), { parent: app.actor });
+    const ownedItem = new (pf2eItem.constructor as ItemConstructor)(pf2eItem.toJSON(), { parent: app.actor });
     ownedItem.toChat();
   });
 
   $items.on('click', '.item-toggle-equip', function (e) {
-    const action = actionFromEvent(skillActions, e);
-    action.update({ visible: !action.visible });
+    const ownership = actionOwnerships.fromEvent(e);
+    ownership?.update({ visible: !ownership.visible });
   });
 
   const target = $(html).find('.actions-list.item-list.directory-list.strikes-list');
   target.after(skillActionHtml);
 });
-
-function initializeSkillActions(actor: Actor): Record<string, SkillAction> {
-  return {
-    disarm: new SkillAction('disarm', 'Disarm', 'ath', true, 'perfect-strike', false, actor, { includeMap: true }),
-    grapple: new SkillAction('grapple', 'Grapple', 'ath', false, 'remove-fear', false, actor, { includeMap: true }),
-    trip: new SkillAction('trip', 'Trip', 'ath', false, 'natures-enmity', false, actor, { includeMap: true }),
-    demoralize: new SkillAction('demoralize', 'Demoralize', 'itm', false, 'blind-ambition', false, actor),
-    shove: new SkillAction('shove', 'Shove', 'ath', false, 'ki-strike', false, actor, { includeMap: true }),
-    feint: new SkillAction('feint', 'Feint', 'dec', true, 'delay-consequence', false, actor),
-    bonMot: new SkillAction('bonMot', 'Bon Mot', 'dip', false, 'hideous-laughter', true, actor),
-  };
-}

--- a/src/module/skill-actions-collections.ts
+++ b/src/module/skill-actions-collections.ts
@@ -1,0 +1,51 @@
+import SkillAction, { SkillActionOwnership } from './skill-actions';
+
+export class IndexedCollection<T extends { key: string }> {
+  elements: T[];
+  indexed: Map<string, T>;
+
+  constructor() {
+    this.elements = [];
+    this.indexed = new Map<string, T>();
+  }
+
+  get all() {
+    return this.elements;
+  }
+
+  add(e: T) {
+    this.elements.push(e);
+    this.indexed.set(e.key, e);
+  }
+
+  get(key: string) {
+    return this.indexed.get(key);
+  }
+}
+
+export class SkillActions extends IndexedCollection<SkillAction> {
+  constructor() {
+    super();
+    this.add(new SkillAction('disarm', 'Disarm', 'ath', true, 'perfect-strike', false));
+    this.add(new SkillAction('grapple', 'Grapple', 'ath', false, 'remove-fear', false));
+    this.add(new SkillAction('trip', 'Trip', 'ath', false, 'natures-enmity', false));
+    this.add(new SkillAction('demoralize', 'Demoralize', 'itm', false, 'blind-ambition', false));
+    this.add(new SkillAction('shove', 'Shove', 'ath', false, 'ki-strike', false));
+    this.add(new SkillAction('feint', 'Feint', 'dec', true, 'delay-consequence', false));
+    this.add(new SkillAction('bonMot', 'Bon Mot', 'dip', false, 'hideous-laughter', true));
+  }
+}
+
+export class SkillActionOwnerships extends IndexedCollection<SkillActionOwnership> {
+  constructor(skillActions: SkillActions, actor: Actor) {
+    super();
+    skillActions.all
+      .map((action) => new SkillActionOwnership(action, actor))
+      .filter((ownership) => ownership.enabled)
+      .forEach((ownership) => this.add(ownership));
+  }
+
+  fromEvent(e: JQuery.TriggeredEvent) {
+    return this.get(e.delegateTarget.dataset.actionId);
+  }
+}

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -1,9 +1,4 @@
-import SkillAction from './skill-actions';
 import { PF2eActorFlag } from './globals';
-
-export function actionFromEvent(skillActions: Record<string, SkillAction>, e: JQuery.TriggeredEvent) {
-  return skillActions[e.delegateTarget.dataset.actionId];
-}
 
 export const Flag = {
   set: async function <K extends keyof PF2eActorFlag, V extends PF2eActorFlag[K]>(actor: Actor, key: K, data: V) {

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -1,0 +1,15 @@
+import SkillAction from './skill-actions';
+import { PF2eActorFlag } from './globals';
+
+export function actionFromEvent(skillActions: Record<string, SkillAction>, e: JQuery.TriggeredEvent) {
+  return skillActions[e.delegateTarget.dataset.actionId];
+}
+
+export const Flag = {
+  set: async function <K extends keyof PF2eActorFlag, V extends PF2eActorFlag[K]>(actor: Actor, key: K, data: V) {
+    await actor.setFlag('pf2e-sheet-skill-actions', key, data);
+  },
+  get: function <K extends keyof PF2eActorFlag>(actor: Actor, key: K): PF2eActorFlag[K] {
+    return actor.getFlag('pf2e-sheet-skill-actions', key);
+  },
+} as const;

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -1,20 +1,30 @@
 <ol class="actions-list item-list inventory-list directory-list skill-action-list">
   <li class="action-header">
     <h3 class="pf-heading pf-actions">Skill Actions</h3>
+    <div class="item-controls">
+      <a class="item-control toggle-hidden-actions" title="Toggle hidden actions">
+        <i class="fas fa-tshirt" {{#if allVisible}}style="color: rgba(0, 0, 0, 0.4);"{{/if}}></i>
+      </a>
+    </div>
   </li>
-  {{#each skills}} {{#if hidden}}
-  <li class="item expandable ready" draggable="true">
+  {{#each skills}} {{#if enabled}}
+  <li class="item expandable ready" draggable="true" data-action-id="{{key}}">
     <div class="item-name">
-      <div class="item-image variant-strike" data-item-label="{{ itemName }}" style="background-image: url({{icon}})">
+      <div class="item-image variant-strike" style="background-image: url({{icon}})">
         <i class="fas fa-comment-alt"></i>
       </div>
       <div class="actions-title">
         <div class="action-name">
           <h4>{{label}} <span class="activity-icon">A</span></h4>
+          <div class="action-options">
+            <a class="item-control item-toggle-equip {{#if visible}}active{{/if}}" title="Toggle action visibility">
+              <i class="fas fa-tshirt"></i>
+            </a>
+          </div>
         </div>
         <div class="button-group tags">
           {{#each rollOptions}}
-          <button id="{{../key}}" type="button" class="skill-action tag variant-strike" data-map="{{map}}">{{label}}</button>
+          <button type="button" class="skill-action tag variant-strike" data-map="{{map}}">{{label}}</button>
           {{/each}}
         </div>
       </div>


### PR DESCRIPTION
Depends on #16 
- Separates action definition from action action ownership. This means that definitions can be reused between actors and perhaps even moved to compendium at some point.
- Introduce collection classes for skill actions & skill action ownerships.
- Moved `fromEvent` function to skill action ownerships collection.