### PR TITLE
Add more basic skill actions

### DIFF
--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -1,4 +1,57 @@
-export const SKILL_ACTIONS_DATA = [
+import { PartialBy } from './utils';
+
+export type ActionType = 'A' | 'D' | 'T' | 'F' | 'R' | '';
+
+export interface SkillActionData {
+  key: string;
+  label: string;
+  translation: string;
+  icon: string;
+  proficiencyKey: string;
+  trainingRequired: boolean;
+  featSlug?: string;
+  actionType: ActionType;
+  actor: Actor;
+}
+
+export type SkillActionDataParameters = PartialBy<SkillActionData, 'actionType' | 'icon'>;
+
+export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
+  {
+    key: 'balance',
+    label: 'Balance',
+    translation: 'PF2E.Actions.Balance.Title',
+    proficiencyKey: 'acr',
+    trainingRequired: false,
+  },
+  {
+    key: 'tumbleThrough',
+    label: 'Tumble Through',
+    translation: 'PF2E.Actions.TumbleThrough.Title',
+    proficiencyKey: 'acr',
+    trainingRequired: false,
+  },
+  {
+    key: 'maneuverInFlight',
+    label: 'Maneuver in Flight',
+    translation: 'PF2E.Actions.ManeuverInFlight.Title',
+    proficiencyKey: 'acr',
+    trainingRequired: true,
+  },
+  {
+    key: 'climb',
+    label: 'Climb',
+    translation: 'PF2E.Actions.Climb.Title',
+    proficiencyKey: 'ath',
+    trainingRequired: false,
+  },
+  {
+    key: 'forceOpen',
+    label: 'Force Open',
+    translation: 'PF2E.Actions.ForceOpen.Title',
+    proficiencyKey: 'ath',
+    trainingRequired: false,
+  },
   {
     key: 'disarm',
     label: 'Disarm',
@@ -6,7 +59,6 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'ath',
     trainingRequired: true,
     icon: 'perfect-strike',
-    featRequired: false,
   },
   {
     key: 'grapple',
@@ -15,7 +67,29 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'ath',
     trainingRequired: false,
     icon: 'remove-fear',
-    featRequired: false,
+  },
+  {
+    key: 'highJump',
+    label: 'High Jump',
+    translation: 'PF2E.Actions.HighJump.Title',
+    proficiencyKey: 'ath',
+    trainingRequired: false,
+    actionType: 'D',
+  },
+  {
+    key: 'longJump',
+    label: 'Long Jump',
+    translation: 'PF2E.Actions.LongJump.Title',
+    proficiencyKey: 'ath',
+    trainingRequired: false,
+    actionType: 'D',
+  },
+  {
+    key: 'swim',
+    label: 'Swim',
+    translation: 'PF2E.Actions.Swim.Title',
+    proficiencyKey: 'ath',
+    trainingRequired: false,
   },
   {
     key: 'trip',
@@ -24,7 +98,6 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'ath',
     trainingRequired: false,
     icon: 'natures-enmity',
-    featRequired: false,
   },
   {
     key: 'demoralize',
@@ -33,7 +106,6 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'itm',
     trainingRequired: false,
     icon: 'blind-ambition',
-    featRequired: false,
   },
   {
     key: 'shove',
@@ -42,7 +114,6 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'ath',
     trainingRequired: false,
     icon: 'ki-strike',
-    featRequired: false,
   },
   {
     key: 'feint',
@@ -51,7 +122,35 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'dec',
     trainingRequired: true,
     icon: 'delay-consequence',
-    featRequired: false,
+  },
+  {
+    key: 'request',
+    label: 'Request',
+    translation: 'PF2E.Actions.Request.Title',
+    proficiencyKey: 'dip',
+    trainingRequired: false,
+  },
+  {
+    key: 'hide',
+    label: 'Hide',
+    translation: 'PF2E.Actions.Hide.Title',
+    proficiencyKey: 'ste',
+    trainingRequired: false,
+  },
+  {
+    key: 'sneak',
+    label: 'Sneak',
+    translation: 'PF2E.Actions.Sneak.Title',
+    proficiencyKey: 'ste',
+    trainingRequired: false,
+  },
+  {
+    key: 'pickALock',
+    label: 'Pick a Lock',
+    translation: 'PF2E.Actions.PickALock.Title',
+    proficiencyKey: 'thi',
+    trainingRequired: true,
+    actionType: 'D',
   },
   {
     key: 'bonMot',
@@ -60,7 +159,6 @@ export const SKILL_ACTIONS_DATA = [
     proficiencyKey: 'dip',
     trainingRequired: false,
     icon: 'hideous-laughter',
-    featRequired: true,
     featSlug: 'bon-mot',
   },
 ];

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -4,7 +4,16 @@
 import { ActionsIndex } from './actions-index';
 import { Flag } from './utils';
 import { ModifierPF2e } from './pf2e';
-import { SKILL_ACTIONS_DATA } from './skill-actions-data';
+import { ActionType, SKILL_ACTIONS_DATA, SkillActionData, SkillActionDataParameters } from './skill-actions-data';
+
+const ACTION_ICONS: Record<ActionType, string> = {
+  A: 'OneAction',
+  D: 'TwoActions',
+  T: 'ThreeActions',
+  F: 'FreeAction',
+  R: 'Reaction',
+  '': 'Passive',
+};
 
 interface RollOption {
   label: string;
@@ -15,23 +24,13 @@ export interface ActorSkillAction {
   visible: boolean;
 }
 
-export interface SkillActionData {
-  key: string;
-  label: string;
-  translation: string;
-  icon: string;
-  proficiencyKey: string;
-  trainingRequired: boolean;
-  featRequired: boolean;
-  featSlug?: string;
-  actor: Actor;
-}
-
 export class SkillAction {
   data: SkillActionData;
 
-  constructor(data: SkillActionData) {
-    data.icon = 'systems/pf2e/icons/spells/' + data.icon + '.webp';
+  constructor(data: SkillActionDataParameters) {
+    data.actionType ??= 'A';
+    if (data.icon) data.icon = 'systems/pf2e/icons/spells/' + data.icon + '.webp';
+    else data.icon = 'systems/pf2e/icons/actions/' + ACTION_ICONS[data.actionType] + '.webp';
     this.data = data;
   }
 
@@ -58,7 +57,7 @@ export class SkillAction {
   getData({ allVisible }: { allVisible: boolean }) {
     const enabled =
       (!this.data.trainingRequired || this.skill._modifiers[1].modifier > 0 || this.hasUntrainedImprovisation()) &&
-      (!this.data.featRequired || this.hasFeat()) &&
+      (!this.data.featSlug || this.hasFeat()) &&
       (this.visible || allVisible);
 
     return {

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -1,5 +1,7 @@
 import { PF2eActorFlag } from './globals';
 
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 export const Flag = {
   set: async function <K extends keyof PF2eActorFlag, V extends PF2eActorFlag[K]>(actor: Actor, key: K, data: V) {
     await actor.setFlag('pf2e-sheet-skill-actions', key, data);

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -15,7 +15,7 @@
       </div>
       <div class="actions-title">
         <div class="action-name">
-          <h4>{{label}} <span class="activity-icon">A</span></h4>
+          <h4>{{label}} <span class="activity-icon">{{actionType}}</span></h4>
           <div class="action-options">
             <a class="item-control item-toggle-equip {{#if visible}}active{{/if}}" title="Toggle action visibility">
               <i class="fas fa-tshirt"></i>


### PR DESCRIPTION
Adds all basic skill actions that have their equivalent in `game.pf2e.actions`. The only exception is "Create a Diversion", which requires a variant when rolled, so it wasn't added.

![image](https://user-images.githubusercontent.com/25230/153261986-05545633-313a-4268-8f2e-99e7cd1f52c5.png)
![image](https://user-images.githubusercontent.com/25230/153262037-19d23b9c-bd60-4d4e-8cbe-9f18dfa37a07.png)

