### PR TITLE
Use slugs to link PF2e items and minimize data to add new action

### DIFF
--- a/src/module/actions-index.ts
+++ b/src/module/actions-index.ts
@@ -1,7 +1,7 @@
 import { ItemPF2e } from './globals';
 import { SKILL_ACTIONS_DATA } from './skill-actions-data';
 
-const ACTION_NAMES = SKILL_ACTIONS_DATA.map((row) => row.label);
+const ACTION_SLUGS = SKILL_ACTIONS_DATA.map((row) => row.slug);
 
 export class ActionsIndex extends Map<string, ItemPF2e> {
   private static _instance: ActionsIndex;
@@ -21,9 +21,9 @@ export class ActionsIndex extends Map<string, ItemPF2e> {
     const pack = game.packs.get(packName);
     if (!pack) return;
 
-    const actions = await pack.getDocuments({ name: { $in: ACTION_NAMES } });
+    const actions = await pack.getDocuments({ 'data.slug': { $in: ACTION_SLUGS } });
     for (const action of actions) {
-      if (action instanceof Item && action.name) this.set(action.name, action);
+      if (action instanceof Item && action.slug) this.set(action.slug, action);
     }
   }
 }

--- a/src/module/globals.d.ts
+++ b/src/module/globals.d.ts
@@ -17,6 +17,20 @@ export interface ItemTraits extends ValuesList {
   rarity: string;
 }
 
+export type Rank = 0 | 1 | 2 | 3 | 4;
+
+interface CharacterSkillData {
+  rank: Rank;
+}
+
+interface BaseActorDataPF2e {
+  skills: Record<string, CharacterSkillData>;
+}
+
+interface BaseActorSourcePF2e {
+  data: BaseActorDataPF2e;
+}
+
 interface BaseItemDataPF2e {
   traits?: ItemTraits;
 }
@@ -26,6 +40,7 @@ interface BaseItemSourcePF2e {
 }
 
 export class ItemPF2e extends Item {
+  slug: string | null;
   toChat(event?: JQuery.TriggeredEvent): Promise<undefined>;
   calculateMap(): { label: string; map2: number; map3: number };
 }
@@ -47,6 +62,7 @@ declare global {
     Item: typeof ItemPF2e;
   }
   interface DataConfig {
+    Actor: BaseActorSourcePF2e;
     Item: BaseItemSourcePF2e;
   }
   interface FlagConfig {

--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -1,176 +1,140 @@
 import { PartialBy } from './utils';
+import { Rank } from './globals';
 
 export type ActionType = 'A' | 'D' | 'T' | 'F' | 'R' | '';
 
 export interface SkillActionData {
   key: string;
-  label: string;
-  translation: string;
+  slug: string;
   icon: string;
   proficiencyKey: string;
-  trainingRequired: boolean;
-  featSlug?: string;
+  requiredRank: Rank;
   actionType: ActionType;
   actor: Actor;
 }
 
-export type SkillActionDataParameters = PartialBy<SkillActionData, 'actionType' | 'icon'>;
+export type SkillActionDataParameters = PartialBy<SkillActionData, 'actionType' | 'icon' | 'requiredRank'>;
 
 export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   {
     key: 'balance',
-    label: 'Balance',
-    translation: 'PF2E.Actions.Balance.Title',
+    slug: 'balance',
     proficiencyKey: 'acr',
-    trainingRequired: false,
     icon: 'freedom-of-movement',
   },
   {
     key: 'tumbleThrough',
-    label: 'Tumble Through',
-    translation: 'PF2E.Actions.TumbleThrough.Title',
+    slug: 'tumble-through',
     proficiencyKey: 'acr',
-    trainingRequired: false,
     icon: 'unimpeded-stride',
   },
   {
     key: 'maneuverInFlight',
-    label: 'Maneuver in Flight',
-    translation: 'PF2E.Actions.ManeuverInFlight.Title',
+    slug: 'maneuver-in-flight',
     proficiencyKey: 'acr',
-    trainingRequired: true,
+    requiredRank: 1,
     icon: 'fleet-step',
   },
   {
     key: 'climb',
-    label: 'Climb',
-    translation: 'PF2E.Actions.Climb.Title',
+    slug: 'climb',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     icon: 'heroic-feat',
   },
   {
     key: 'forceOpen',
-    label: 'Force Open',
-    translation: 'PF2E.Actions.ForceOpen.Title',
+    slug: 'force-open',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     icon: 'indestructibility',
   },
   {
     key: 'disarm',
-    label: 'Disarm',
-    translation: 'PF2E.Actions.Disarm.Title',
+    slug: 'disarm',
     proficiencyKey: 'ath',
-    trainingRequired: true,
+    requiredRank: 1,
     icon: 'perfect-strike',
   },
   {
     key: 'grapple',
-    label: 'Grapple',
-    translation: 'PF2E.Actions.Grapple.Title',
+    slug: 'grapple',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     icon: 'remove-fear',
   },
   {
     key: 'highJump',
-    label: 'High Jump',
-    translation: 'PF2E.Actions.HighJump.Title',
+    slug: 'high-jump',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     actionType: 'D',
     icon: 'jump',
   },
   {
     key: 'longJump',
-    label: 'Long Jump',
-    translation: 'PF2E.Actions.LongJump.Title',
+    slug: 'long-jump',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     actionType: 'D',
     icon: 'longstrider',
   },
   {
     key: 'swim',
-    label: 'Swim',
-    translation: 'PF2E.Actions.Swim.Title',
+    slug: 'swim',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     icon: 'waters-of-prediction',
   },
   {
     key: 'trip',
-    label: 'Trip',
-    translation: 'PF2E.Actions.Trip.Title',
+    slug: 'trip',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     icon: 'natures-enmity',
   },
   {
     key: 'demoralize',
-    label: 'Demoralize',
-    translation: 'PF2E.Actions.Demoralize.Title',
+    slug: 'demoralize',
     proficiencyKey: 'itm',
-    trainingRequired: false,
     icon: 'blind-ambition',
   },
   {
     key: 'shove',
-    label: 'Shove',
-    translation: 'PF2E.Actions.Shove.Title',
+    slug: 'shove',
     proficiencyKey: 'ath',
-    trainingRequired: false,
     icon: 'ki-strike',
   },
   {
     key: 'feint',
-    label: 'Feint',
-    translation: 'PF2E.Actions.Feint.Title',
+    slug: 'feint',
     proficiencyKey: 'dec',
-    trainingRequired: true,
+    requiredRank: 1,
     icon: 'delay-consequence',
   },
   {
     key: 'request',
-    label: 'Request',
-    translation: 'PF2E.Actions.Request.Title',
+    slug: 'request',
     proficiencyKey: 'dip',
-    trainingRequired: false,
     icon: 'cackle',
   },
   {
     key: 'hide',
-    label: 'Hide',
-    translation: 'PF2E.Actions.Hide.Title',
+    slug: 'hide',
     proficiencyKey: 'ste',
-    trainingRequired: false,
     icon: 'zealous-conviction',
   },
   {
     key: 'sneak',
-    label: 'Sneak',
-    translation: 'PF2E.Actions.Sneak.Title',
+    slug: 'sneak',
     proficiencyKey: 'ste',
-    trainingRequired: false,
     icon: 'invisibility',
   },
   {
     key: 'pickALock',
-    label: 'Pick a Lock',
-    translation: 'PF2E.Actions.PickALock.Title',
+    slug: 'pick-a-lock',
     proficiencyKey: 'thi',
-    trainingRequired: true,
+    requiredRank: 1,
     actionType: 'D',
     icon: 'ward-domain',
   },
   {
     key: 'bonMot',
-    label: 'Bon Mot',
-    translation: 'PF2E.Actions.BonMot.Title',
+    slug: 'bon-mot',
     proficiencyKey: 'dip',
-    trainingRequired: false,
     icon: 'hideous-laughter',
-    featSlug: 'bon-mot',
   },
 ];


### PR DESCRIPTION
- Now uses slugs to get ItemPF2e, whether it's in actor or in compendium.
- Reduces amount of data needed to introduce new action by using available data in compendium & setting some default.
- Use `skill.rank` to determine actor's rank in skill, also convert `trainingRequired` to `requiredRank` both because it's easier to work with but also to support expert/master/legendary actions.
- Simplify and DRY item finding on actor.