### PR TITLE
Add support for actions undefined in game.pf2e.actions

### DIFF
--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -62,11 +62,7 @@ Hooks.on('renderActorSheet', async (app: ActorSheet, html: JQuery<HTMLElement>) 
   });
 
   $items.on('click', '.item-image', function (e) {
-    const pf2eItem = skillActions.fromEvent(e).pf2eItem;
-    if (!pf2eItem) return;
-
-    const ownedItem = new (pf2eItem.constructor as ItemConstructor)(pf2eItem.toJSON(), { parent: app.actor });
-    ownedItem.toChat();
+    skillActions.fromEvent(e).toChat();
   });
 
   $items.on('click', '.item-toggle-equip', function (e) {

--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -132,6 +132,11 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     icon: 'ward-domain',
   },
   {
+    key: 'steal',
+    slug: 'steal',
+    proficiencyKey: 'thi',
+  },
+  {
     key: 'bonMot',
     slug: 'bon-mot',
     proficiencyKey: 'dip',


### PR DESCRIPTION
Not sure if formatting is great, but I don't think there's any other way. Basically it all comes down to 2 things:
1. We can't access `CheckPF2e.roll` from module.
2. `skill.roll` has very limited amount of options it supports, we can't pass custom label or traits.

So this is the best we can currently do. The only other meaningful option that I'm not using is `dc`, so I think we would be able to set DC of the check in the future (in case target is selected).

So in the end what it does when you roll "Steal" is post the action to the chat and then roll thievery. If this is good enough I'll add the remaining encounter mode skill actions.

BTW this also fixes #7 

![image](https://user-images.githubusercontent.com/25230/153305231-1250138b-d86f-423d-8c0f-6776e4523aa8.png)
