### PR TITLE
Make key optional and derrive it from slug when it's not specified

### DIFF
--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -13,118 +13,100 @@ export interface SkillActionData {
   actor: Actor;
 }
 
-export type SkillActionDataParameters = PartialBy<SkillActionData, 'actionType' | 'icon' | 'requiredRank'>;
+export type SkillActionDataParameters = PartialBy<SkillActionData, 'key' | 'actionType' | 'icon' | 'requiredRank'>;
 
 export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   {
-    key: 'balance',
     slug: 'balance',
     proficiencyKey: 'acr',
     icon: 'freedom-of-movement',
   },
   {
-    key: 'tumbleThrough',
     slug: 'tumble-through',
     proficiencyKey: 'acr',
     icon: 'unimpeded-stride',
   },
   {
-    key: 'maneuverInFlight',
     slug: 'maneuver-in-flight',
     proficiencyKey: 'acr',
     requiredRank: 1,
     icon: 'fleet-step',
   },
   {
-    key: 'climb',
     slug: 'climb',
     proficiencyKey: 'ath',
     icon: 'heroic-feat',
   },
   {
-    key: 'forceOpen',
     slug: 'force-open',
     proficiencyKey: 'ath',
     icon: 'indestructibility',
   },
   {
-    key: 'disarm',
     slug: 'disarm',
     proficiencyKey: 'ath',
     requiredRank: 1,
     icon: 'perfect-strike',
   },
   {
-    key: 'grapple',
     slug: 'grapple',
     proficiencyKey: 'ath',
     icon: 'remove-fear',
   },
   {
-    key: 'highJump',
     slug: 'high-jump',
     proficiencyKey: 'ath',
     actionType: 'D',
     icon: 'jump',
   },
   {
-    key: 'longJump',
     slug: 'long-jump',
     proficiencyKey: 'ath',
     actionType: 'D',
     icon: 'longstrider',
   },
   {
-    key: 'swim',
     slug: 'swim',
     proficiencyKey: 'ath',
     icon: 'waters-of-prediction',
   },
   {
-    key: 'trip',
     slug: 'trip',
     proficiencyKey: 'ath',
     icon: 'natures-enmity',
   },
   {
-    key: 'demoralize',
     slug: 'demoralize',
     proficiencyKey: 'itm',
     icon: 'blind-ambition',
   },
   {
-    key: 'shove',
     slug: 'shove',
     proficiencyKey: 'ath',
     icon: 'ki-strike',
   },
   {
-    key: 'feint',
     slug: 'feint',
     proficiencyKey: 'dec',
     requiredRank: 1,
     icon: 'delay-consequence',
   },
   {
-    key: 'request',
     slug: 'request',
     proficiencyKey: 'dip',
     icon: 'cackle',
   },
   {
-    key: 'hide',
     slug: 'hide',
     proficiencyKey: 'ste',
     icon: 'zealous-conviction',
   },
   {
-    key: 'sneak',
     slug: 'sneak',
     proficiencyKey: 'ste',
     icon: 'invisibility',
   },
   {
-    key: 'pickALock',
     slug: 'pick-a-lock',
     proficiencyKey: 'thi',
     requiredRank: 1,
@@ -132,12 +114,10 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     icon: 'ward-domain',
   },
   {
-    key: 'steal',
     slug: 'steal',
     proficiencyKey: 'thi',
   },
   {
-    key: 'bonMot',
     slug: 'bon-mot',
     proficiencyKey: 'dip',
     icon: 'hideous-laughter',

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -29,6 +29,7 @@ export class SkillAction {
   data: SkillActionData;
 
   constructor(data: SkillActionDataParameters) {
+    data.key ??= data.slug.replace(/-(\w)/g, (_, letter) => letter.toUpperCase());
     data.requiredRank ??= 0;
     data.actionType ??= 'A';
     if (data.icon) data.icon = 'systems/pf2e/icons/spells/' + data.icon + '.webp';
@@ -137,7 +138,8 @@ export class SkillActionCollection extends Collection<SkillAction> {
   constructor(actor: Actor) {
     super(
       deepClone(SKILL_ACTIONS_DATA).map(function (row) {
-        return [row.key, new SkillAction({ ...row, actor: actor })];
+        const action = new SkillAction({ ...row, actor: actor });
+        return [action.key, action];
       }),
     );
   }


### PR DESCRIPTION
Removes the last parameter we can derive from other data: `key`. I thought whether to remove `key` or `slug`, but in the end I went with `key`, because `slug` is used to match actions in pf2e compendium and there's a chance that `key` will not be needed in the future at all. 