### PR TITLE
Add quick search to skill actions

### DIFF
--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -14,7 +14,6 @@
 import { registerSettings } from './settings';
 import { preloadTemplates } from './preloadTemplates';
 import { ActionsIndex } from './actions-index';
-import { ItemConstructor } from './globals';
 import { Flag } from './utils';
 import { SkillActionCollection } from './skill-actions';
 
@@ -55,6 +54,14 @@ Hooks.on('renderActorSheet', async (app: ActorSheet, html: JQuery<HTMLElement>) 
 
   skillActionHtml.on('click', '.toggle-hidden-actions', function () {
     Flag.set(app.actor, 'allVisible', !Flag.get(app.actor, 'allVisible'));
+  });
+
+  skillActionHtml.on('input', 'input[name="filter"]', function (e) {
+    const filter = e.currentTarget.value.toLowerCase();
+    $items.each(function () {
+      const action = skillActions.fromElement(this);
+      $(this).toggle(action.isDisplayed(filter, allVisible));
+    });
   });
 
   $items.on('click', '.skill-action.tag.variant-strike', function (e) {

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -44,6 +44,10 @@ export class SkillAction {
     return this.data.key;
   }
 
+  get label() {
+    return game.i18n.localize(this.skill.label) + ': ' + this.pf2eItem.name;
+  }
+
   get skill() {
     return this.actor.data.data.skills[this.data.proficiencyKey];
   }
@@ -56,15 +60,23 @@ export class SkillAction {
     return ActionsIndex.instance.get(this.data.slug);
   }
 
+  isDisplayed(filter: string, allVisible: boolean) {
+    if (filter) {
+      return this.label.toLowerCase().includes(filter);
+    } else {
+      return this.visible || allVisible;
+    }
+  }
+
   getData({ allVisible }: { allVisible: boolean }) {
-    const enabled =
-      this.hasSkillRank() && (this.pf2eItem.type !== 'feat' || this.actorHasItem()) && (this.visible || allVisible);
+    const enabled = this.hasSkillRank() && (this.pf2eItem.type !== 'feat' || this.actorHasItem());
 
     return {
       ...this.data,
       enabled: enabled,
       visible: this.visible,
-      label: game.i18n.localize(this.skill.label) + ': ' + this.pf2eItem.name,
+      displayed: this.isDisplayed('', allVisible),
+      label: this.label,
       rollOptions: this.rollOptions(),
     };
   }
@@ -142,7 +154,11 @@ export class SkillActionCollection extends Collection<SkillAction> {
     );
   }
 
+  fromElement(el: HTMLElement) {
+    return this.get(el.dataset.actionId, { strict: true });
+  }
+
   fromEvent(e: JQuery.TriggeredEvent) {
-    return this.get(e.delegateTarget.dataset.actionId, { strict: true });
+    return this.fromElement(e.delegateTarget);
   }
 }

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -2,14 +2,17 @@
   <li class="action-header stroke-header">
     {{> systems/pf2e/templates/actors/partials/images/header_stroke.html}}
     <h3 class="pf-heading pf-actions">Skill Actions</h3>
-    <div class="item-controls">
+    <div class="item-controls" style="display: flex; align-items: center">
+      <div class="item-control">
+        <input name="filter" type="text" placeholder="Filter actions">
+      </div>
       <a class="item-control toggle-hidden-actions" title="Toggle hidden actions">
         <i class="fas fa-tshirt" {{#if allVisible}}style="color: rgba(0, 0, 0, 0.4);"{{/if}}></i>
       </a>
     </div>
   </li>
   {{#each skills}} {{#if enabled}}
-  <li class="item expandable ready" draggable="true" data-action-id="{{key}}">
+  <li class="item expandable ready" draggable="true" data-action-id="{{key}}" {{#unless displayed}}style="display:none"{{/unless}}>
     <div class="item-name">
       <div class="item-image variant-strike" style="background-image: url({{icon}})">
         <i class="fas fa-comment-alt"></i>


### PR DESCRIPTION
Adds a quick search input which allows quickly searching actions. It also ignores whether actions is equipped or not, so you can quickly search unequipped actions too.

![image](https://user-images.githubusercontent.com/25230/154743807-bb6b978f-efd9-417d-86a6-e72bcdee8a12.png)

![image](https://user-images.githubusercontent.com/25230/154743884-a2dba636-2ddf-4431-be2c-7e0b6e4be3d1.png)
