### PR TITLE
Add all exploration & downtime actions

### DIFF
--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -30,6 +30,12 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     icon: 'freedom-of-movement',
   },
   {
+    slug: 'squeeze',
+    proficiencyKey: 'acr',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
     slug: 'tumble-through',
     proficiencyKey: 'acr',
     icon: 'unimpeded-stride',
@@ -41,6 +47,33 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     icon: 'fleet-step',
   },
   // Arcana
+  {
+    slug: 'borrow-an-arcane-spell',
+    proficiencyKey: 'arc',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'decipher-writing',
+    key: 'decipherWritingArcana',
+    proficiencyKey: 'arc',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'identify-magic',
+    key: 'identifyMagicArcana',
+    proficiencyKey: 'arc',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'learn-a-spell',
+    key: 'learnASpellArcana',
+    proficiencyKey: 'arc',
+    actionType: '',
+    requiredRank: 1,
+  },
   {
     slug: 'recall-knowledge-arcana',
     proficiencyKey: 'arc',
@@ -96,8 +129,32 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   // Crafting
   {
+    slug: 'craft',
+    proficiencyKey: 'cra',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'earn-income',
+    key: 'earnIncomeCrafting',
+    proficiencyKey: 'cra',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'identify-alchemy',
+    proficiencyKey: 'cra',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
     slug: 'recall-knowledge-crafting',
     proficiencyKey: 'cra',
+  },
+  {
+    slug: 'repair',
+    proficiencyKey: 'cra',
+    actionType: '',
   },
   // Deception
   {
@@ -117,7 +174,27 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     requiredRank: 1,
     icon: 'delay-consequence',
   },
+  {
+    slug: 'impersonate',
+    proficiencyKey: 'dec',
+    actionType: '',
+  },
+  {
+    slug: 'lie',
+    proficiencyKey: 'dec',
+    actionType: '',
+  },
   // Diplomacy
+  {
+    slug: 'gather-information',
+    proficiencyKey: 'dip',
+    actionType: '',
+  },
+  {
+    slug: 'make-an-impression',
+    proficiencyKey: 'dip',
+    actionType: '',
+  },
   {
     slug: 'request',
     proficiencyKey: 'dip',
@@ -125,11 +202,22 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   // Intimidation
   {
+    slug: 'coerce',
+    proficiencyKey: 'itm',
+    actionType: '',
+  },
+  {
     slug: 'demoralize',
     proficiencyKey: 'itm',
     icon: 'blind-ambition',
   },
   // Lore
+  {
+    slug: 'earn-income',
+    proficiencyKey: 'lore',
+    actionType: '',
+    requiredRank: 1,
+  },
   {
     slug: 'recall-knowledge-lore',
     proficiencyKey: 'lore',
@@ -141,8 +229,20 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     actionType: 'D',
   },
   {
+    slug: 'treat-disease',
+    proficiencyKey: 'med',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
     slug: 'treat-poison',
     proficiencyKey: 'med',
+    requiredRank: 1,
+  },
+  {
+    slug: 'treat-wounds',
+    proficiencyKey: 'med',
+    actionType: '',
     requiredRank: 1,
   },
   // Nature
@@ -151,25 +251,107 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     proficiencyKey: 'nat',
   },
   {
+    slug: 'identify-magic',
+    key: 'identifyMagicNature',
+    proficiencyKey: 'nat',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'learn-a-spell',
+    key: 'learnASpellNature',
+    proficiencyKey: 'nat',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
     slug: 'recall-knowledge-nature',
     proficiencyKey: 'nat',
   },
   // Occultism
+  {
+    slug: 'decipher-writing',
+    key: 'decipherWritingOccultism',
+    proficiencyKey: 'occ',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'identify-magic',
+    key: 'identifyMagicOccultism',
+    proficiencyKey: 'occ',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'learn-a-spell',
+    key: 'learnASpellOccultism',
+    proficiencyKey: 'occ',
+    actionType: '',
+    requiredRank: 1,
+  },
   {
     slug: 'recall-knowledge-occultism',
     proficiencyKey: 'occ',
   },
   // Performance
   {
+    slug: 'earn-income',
+    key: 'earnIncomePerformance',
+    proficiencyKey: 'prf',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
     slug: 'perform',
     proficiencyKey: 'prf',
   },
   // Religion
   {
+    slug: 'decipher-writing',
+    key: 'decipherWritingReligion',
+    proficiencyKey: 'rel',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'identify-magic',
+    key: 'identifyMagicReligion',
+    proficiencyKey: 'rel',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'learn-a-spell',
+    key: 'learnASpellReligion',
+    proficiencyKey: 'rel',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
     slug: 'recall-knowledge-religion',
     proficiencyKey: 'rel',
   },
   // Society
+  {
+    slug: 'create-forgery',
+    proficiencyKey: 'soc',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'decipher-writing',
+    key: 'decipherWritingSociety',
+    proficiencyKey: 'soc',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'subsist',
+    key: 'subsistSociety',
+    proficiencyKey: 'soc',
+    actionType: '',
+  },
   {
     slug: 'recall-knowledge-society',
     proficiencyKey: 'soc',
@@ -190,6 +372,29 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     icon: 'invisibility',
   },
   // Survival
+  {
+    slug: 'cover-tracks',
+    proficiencyKey: 'sur',
+    actionType: '',
+    requiredRank: 1,
+  },
+  {
+    slug: 'sense-direction',
+    proficiencyKey: 'sur',
+    actionType: '',
+  },
+  {
+    slug: 'subsist',
+    key: 'subsistSurvival',
+    proficiencyKey: 'sur',
+    actionType: '',
+  },
+  {
+    slug: 'track',
+    proficiencyKey: 'sur',
+    actionType: '',
+    requiredRank: 1,
+  },
   // Thievery
   {
     slug: 'disable-device',

--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -129,6 +129,11 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
     proficiencyKey: 'itm',
     icon: 'blind-ambition',
   },
+  // Lore
+  {
+    slug: 'recall-knowledge-lore',
+    proficiencyKey: 'lore',
+  },
   // Medicine
   {
     slug: 'administer-first-aid',

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -67,6 +67,10 @@ export class SkillAction {
     }
   }
 
+  hasTrait(trait: string) {
+    return this.pf2eItem.data.data.traits.value.includes(trait);
+  }
+
   getData({ allVisible }: { allVisible: boolean }) {
     const enabled = this.hasSkillRank() && (this.pf2eItem.type !== 'feat' || this.actorHasItem());
 
@@ -140,7 +144,7 @@ export class SkillAction {
     } else {
       this.variants = [{ label: `Roll ${modifier}`, map: 0 }];
 
-      if (this.pf2eItem.data.data.traits.value.includes('attack')) {
+      if (this.hasTrait('attack')) {
         const map = this.pf2eItem.calculateMap();
         this.addMapVariant(map.map2);
         this.addMapVariant(map.map3);
@@ -154,8 +158,8 @@ export class SkillAction {
 }
 
 export class SkillActionCollection extends Collection<SkillAction> {
-  constructor(actor: Actor) {
-    const actions = deepClone(SKILL_ACTIONS_DATA).flatMap(function (row) {
+  static allActionsFor(actor) {
+    return deepClone(SKILL_ACTIONS_DATA).flatMap(function (row) {
       if (row.proficiencyKey == 'lore') {
         const skills = actor.data.data.skills;
 
@@ -173,8 +177,11 @@ export class SkillActionCollection extends Collection<SkillAction> {
         return [new SkillAction({ ...row, actor: actor })];
       }
     });
+  }
 
-    super(actions.map((action) => [action.key, action]));
+  add(action: SkillAction) {
+    if (this.get(action.key)) console.warn('Overwriting existing skill action', action.key);
+    this.set(action.key, action);
   }
 
   fromElement(el: HTMLElement) {

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -10,3 +10,7 @@ export const Flag = {
     return actor.getFlag('pf2e-sheet-skill-actions', key);
   },
 } as const;
+
+export function camelize(value: string): string {
+  return value.replace(/-(\w)/g, (_, letter) => letter.toUpperCase());
+}


### PR DESCRIPTION
Adds all exploration & downtime actions into their appropriate tabs.
![image](https://user-images.githubusercontent.com/25230/156838760-49e2feb1-e785-4fb2-8a7e-ed40de1349e6.png)
![image](https://user-images.githubusercontent.com/25230/156838860-aa1f2f69-03b8-4352-a744-c0381b4d7836.png)

![image](https://user-images.githubusercontent.com/25230/156838942-9247917a-9eea-4f83-a663-cc6c1c002e56.png)
