### PR TITLE
Update 3 8

### DIFF
--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -44,7 +44,8 @@ export class SkillAction {
 
   get label() {
     const skillLabel = this.skill.label ? game.i18n.localize(this.skill.label) : this.skill.name;
-    return skillLabel + ': ' + this.pf2eItem.name;
+    const actionLabel = this.data.translation ? game.i18n.localize(this.data.translation) : this.pf2eItem.name;
+    return skillLabel + ': ' + actionLabel;
   }
 
   get skill() {

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -12,7 +12,7 @@
     </div>
   </li>
   {{#each skills}} {{#if enabled}}
-  <li class="item expandable ready" draggable="true" data-action-id="{{key}}" {{#unless displayed}}style="display:none"{{/unless}}>
+  <li class="item action expandable ready" draggable="true" data-action-id="{{key}}" {{#unless displayed}}style="display:none"{{/unless}}>
     <div class="item-name">
       <div class="item-image variant-strike" style="background-image: url({{icon}})">
         <i class="fas fa-comment-alt"></i>
@@ -28,7 +28,7 @@
         </div>
         <div class="button-group tags">
           {{#each variants}}
-          <button type="button" class="skill-action tag variant-strike" data-variant="{{@index}}">{{label}}</button>
+          <button type="button" class="skill-action tag variant-strike" style="width: auto; border: none; cursor: pointer" data-variant="{{@index}}">{{label}}</button>
           {{/each}}
         </div>
       </div>


### PR DESCRIPTION
Fix styles issues in System version 3.8 : 
Before : 
![image](https://user-images.githubusercontent.com/18362479/161508691-6cc42216-8f80-4e4f-b5c1-5f4138d3b20c.png)

After : 
![image](https://user-images.githubusercontent.com/18362479/161508792-56eb4a55-3966-4d66-acf1-50789522af77.png)

I'm far from beeing a css specialist, so consider it a quickfix : I only added styles until it looked readable :D


I also added skill translation use, but this is not enough to fix https://github.com/jamespdaily/pf2e-sheet-skill-actions/issues/40, I still have to figure how to get all the translations for items that comes from compendiums and not from system.