### PR TITLE
Full translations of all actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ I love you.
 * Go to https://github.com/jamespdaily/pf2e-sheet-skill-actions/edit/master/src/module/skill-actions-data.ts
 * Find a section relevant for your action and add JSON for your action. Keys explained:
   * **slug** (required) - slug to match PF2e action item in compendium. To get the slug: find the name of the action/feat in PF2e compendium, remove "'" and "`" characters, replace anything that's not a letter or number with "-" and downcase everything.
+  * **compendiumID** (required) - ID of the action or feat in the compendium. You can drag and drop the action in a jounal to find the link generated (like @Compendium[pf2e.actionspf2e.S9PZFOVe7zhORkUc]).
   * **proficiencyKey** (required) - 3 letter acronym for the skill in PF2e (`acr`, `arc`, `ath`, `cra`, `dec`, `dip`, `itm`, `med`, `nat`, `occ`, `prf`, `rel`, `soc`, `ste`, `sur`, `thi`)
   * **icon** - name of icon in `[FOUNDRY DATA]/Data/systems/pf2e/icons/spells` to use.
   * **requiredRank** - add action requires training in skill. 0 - untrained (default), 1 - trained, 2 - expert, 3 - master, 4 - legendary.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ const distDirectory = './dist';
 const stylesDirectory = `${sourceDirectory}/styles`;
 const stylesExtension = 'scss';
 const sourceFileExtension = 'ts';
-const staticFiles = ['templates', 'module.json'];
+const staticFiles = ['templates', 'module.json', 'lang'];
 const getDownloadURL = (version) => `https://host/path/to/${version}.zip`;
 
 /********************/

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,0 +1,5 @@
+{
+  "SkillActions": {
+    "Title": "Skill Actions"
+  }
+}

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1,0 +1,5 @@
+{
+  "SkillActions": {
+    "Title": "Actions de Compétence"
+  }
+}

--- a/src/module.json
+++ b/src/module.json
@@ -14,6 +14,18 @@
   "minimumCoreVersion": "0.8.9",
   "compatibleCoreVersion": "9",
   "esmodules": ["module/sheet-skill-actions.js"],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    },
+    {
+      "lang": "fr",
+      "name": "Français",
+      "path": "lang/fr.json"
+    }
+  ],
   "url": "",
   "manifest": "",
   "download": "https://host/path/to/0.1.0.zip",

--- a/src/module/actions-index.ts
+++ b/src/module/actions-index.ts
@@ -1,7 +1,7 @@
 import { ItemPF2e } from './globals';
 import { SKILL_ACTIONS_DATA } from './skill-actions-data';
 
-const ACTION_SLUGS = SKILL_ACTIONS_DATA.map((row) => row.slug);
+const ACTION_IDS = SKILL_ACTIONS_DATA.map((row) => row.compendiumId);
 
 export class ActionsIndex extends Map<string, ItemPF2e> {
   private static _instance: ActionsIndex;
@@ -21,7 +21,7 @@ export class ActionsIndex extends Map<string, ItemPF2e> {
     const pack = game.packs.get(packName);
     if (!pack) return;
 
-    const actions = await pack.getDocuments({ 'data.slug': { $in: ACTION_SLUGS } });
+    const actions = await pack.getDocuments({ _id: { $in: ACTION_IDS } });
     for (const action of actions) {
       if (action instanceof Item && action.slug) this.set(action.slug, action);
     }

--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -35,6 +35,12 @@ Hooks.once('ready', async () => {
   await ActionsIndex.instance.loadCompendium('pf2e.actionspf2e');
 });
 
+Hooks.once('babele.ready', async () => {
+  //Reload actions to have translated actions
+  await ActionsIndex.instance.loadCompendium('pf2e.feats-srd');
+  await ActionsIndex.instance.loadCompendium('pf2e.actionspf2e');
+});
+
 async function renderActionsList(skillActions: SkillActionCollection, actor: Actor) {
   const tpl = 'modules/pf2e-sheet-skill-actions/templates/skill-actions.html';
   const allVisible = Flag.get(actor, 'allVisible');

--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -13,7 +13,7 @@ interface Variant {
 export interface SkillActionData {
   key: string;
   slug: string;
-  translation: string;
+  compendiumId: string;
   icon: string;
   proficiencyKey: string;
   requiredRank: Rank;
@@ -24,32 +24,33 @@ export interface SkillActionData {
 
 export type SkillActionDataParameters = PartialBy<
   SkillActionData,
-  'key' | 'actionType' | 'icon' | 'requiredRank' | 'translation'
+  'key' | 'actionType' | 'icon' | 'requiredRank' | 'compendiumId'
 >;
 
 export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   // Acrobatics
   {
     slug: 'balance',
-    translation: 'PF2E.Actions.Balance.Title',
+    compendiumId: 'M76ycLAqHoAgbcej',
     proficiencyKey: 'acr',
     icon: 'freedom-of-movement',
   },
   {
     slug: 'squeeze',
+    compendiumId: 'kMcV8e5EZUxa6evt',
     proficiencyKey: 'acr',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'tumble-through',
-    translation: 'PF2E.Actions.TumbleThrough.Title',
+    compendiumId: '21WIfSu7Xd7uKqV8',
     proficiencyKey: 'acr',
     icon: 'unimpeded-stride',
   },
   {
     slug: 'maneuver-in-flight',
-    translation: 'PF2E.Actions.ManeuverInFlight.Title',
+    compendiumId: 'Qf1ylAbdVi1rkc8M',
     proficiencyKey: 'acr',
     requiredRank: 1,
     icon: 'fleet-step',
@@ -57,12 +58,14 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   // Arcana
   {
     slug: 'borrow-an-arcane-spell',
+    compendiumId: 'OizxuPb44g3eHPFh',
     proficiencyKey: 'arc',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'decipher-writing',
+    compendiumId: 'd9gbpiQjChYDYA2L',
     key: 'decipherWritingArcana',
     proficiencyKey: 'arc',
     actionType: '',
@@ -70,6 +73,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'identify-magic',
+    compendiumId: 'eReSHVEPCsdkSL4G',
     key: 'identifyMagicArcana',
     proficiencyKey: 'arc',
     actionType: '',
@@ -77,6 +81,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'learn-a-spell',
+    compendiumId: 'Q5iIYCFdqJFM31GW',
     key: 'learnASpellArcana',
     proficiencyKey: 'arc',
     actionType: '',
@@ -84,76 +89,78 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'recall-knowledge-arcana',
-    translation: 'PF2E.RecallKnowledge.Label',
+    compendiumId: 'KygTSeDvsFoSO6HW',
     proficiencyKey: 'arc',
   },
   // Athletics
   {
     slug: 'climb',
-    translation: 'PF2E.Actions.Climb.Title',
+    compendiumId: 'pprgrYQ1QnIDGZiy',
     proficiencyKey: 'ath',
     icon: 'heroic-feat',
   },
   {
     slug: 'force-open',
-    translation: 'PF2E.Actions.ForceOpen.Title',
+    compendiumId: 'SjmKHgI7a5Z9JzBx',
     proficiencyKey: 'ath',
     icon: 'indestructibility',
   },
   {
     slug: 'disarm',
-    translation: 'PF2E.Actions.Disarm.Title',
+    compendiumId: 'Dt6B1slsBy8ipJu9',
     proficiencyKey: 'ath',
     requiredRank: 1,
     icon: 'perfect-strike',
   },
   {
     slug: 'grapple',
-    translation: 'PF2E.Actions.Grapple.Title',
+    compendiumId: 'PMbdMWc2QroouFGD',
     proficiencyKey: 'ath',
     icon: 'remove-fear',
   },
   {
     slug: 'high-jump',
-    translation: 'PF2E.Actions.HighJump.Title',
+    compendiumId: '2HJ4yuEFY1Cast4h',
     proficiencyKey: 'ath',
     actionType: 'D',
     icon: 'jump',
   },
   {
     slug: 'long-jump',
-    translation: 'PF2E.Actions.LongJump.Title',
+    compendiumId: 'JUvAvruz7yRQXfz2',
     proficiencyKey: 'ath',
     actionType: 'D',
     icon: 'longstrider',
   },
   {
     slug: 'shove',
-    translation: 'PF2E.Actions.Shove.Title',
+    compendiumId: '7blmbDrQFNfdT731',
     proficiencyKey: 'ath',
     icon: 'ki-strike',
   },
   {
     slug: 'swim',
-    translation: 'PF2E.Actions.Swim.Title',
+    compendiumId: 'c8TGiZ48ygoSPofx',
     proficiencyKey: 'ath',
     icon: 'waters-of-prediction',
   },
   {
     slug: 'trip',
-    translation: 'PF2E.Actions.Trip.Title',
+    compendiumId: 'ge56Lu1xXVFYUnLP',
     proficiencyKey: 'ath',
     icon: 'natures-enmity',
   },
   // Crafting
   {
     slug: 'craft',
+    compendiumId: 'rmwa3OyhTZ2i2AHl',
     proficiencyKey: 'cra',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'earn-income',
+    compendiumId: 'QyzlsLrqM0EEwd7j',
     key: 'earnIncomeCrafting',
     proficiencyKey: 'cra',
     actionType: '',
@@ -161,23 +168,26 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'identify-alchemy',
+    compendiumId: 'Q4kdWVOf2ztIBFg1',
     proficiencyKey: 'cra',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'recall-knowledge-crafting',
-    translation: 'PF2E.RecallKnowledge.Label',
+    compendiumId: 'B0Eu3EfwIa9kyDEA',
     proficiencyKey: 'cra',
   },
   {
     slug: 'repair',
+    compendiumId: 'bT3skovyLUtP22ME',
     proficiencyKey: 'cra',
     actionType: '',
   },
   // Deception
   {
     slug: 'create-a-diversion',
+    compendiumId: 'GkmbTGfg8KcgynOA',
     proficiencyKey: 'dec',
     variants: function () {
       return [
@@ -189,80 +199,91 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'feint',
-    translation: 'PF2E.Actions.Feint.Title',
+    compendiumId: 'QNAVeNKtHA0EUw4X',
     proficiencyKey: 'dec',
     requiredRank: 1,
     icon: 'delay-consequence',
   },
   {
     slug: 'impersonate',
+    compendiumId: 'AJstokjdG6iDjVjE',
     proficiencyKey: 'dec',
     actionType: '',
   },
   {
     slug: 'lie',
+    compendiumId: 'ewwCglB7XOPLUz72',
     proficiencyKey: 'dec',
     actionType: '',
   },
   // Diplomacy
   {
     slug: 'gather-information',
+    compendiumId: 'plBGdZhqq5JBl1D8',
     proficiencyKey: 'dip',
     actionType: '',
   },
   {
     slug: 'make-an-impression',
+    compendiumId: 'OX4fy22hQgUHDr0q',
     proficiencyKey: 'dip',
     actionType: '',
   },
   {
     slug: 'request',
-    translation: 'PF2E.Actions.Request.Title',
+    compendiumId: 'DCb62iCBrJXy0Ik6',
     proficiencyKey: 'dip',
     icon: 'cackle',
   },
   // Intimidation
   {
     slug: 'coerce',
+    compendiumId: 'tHCqgwjtQtzNqVvd',
     proficiencyKey: 'itm',
     actionType: '',
   },
   {
     slug: 'demoralize',
-    translation: 'PF2E.Actions.Demoralize.Title',
+    compendiumId: '2u915NdUyQan6uKF',
     proficiencyKey: 'itm',
     icon: 'blind-ambition',
   },
   // Lore
   {
     slug: 'earn-income',
+    compendiumId: 'QyzlsLrqM0EEwd7j',
     proficiencyKey: 'lore',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'recall-knowledge-lore',
+    compendiumId: '1OagaWtBpVXExToo',
     proficiencyKey: 'lore',
   },
   // Medicine
   {
     slug: 'administer-first-aid',
+    compendiumId: 'MHLuKy4nQO2Z4Am1',
     proficiencyKey: 'med',
     actionType: 'D',
   },
   {
     slug: 'treat-disease',
+    compendiumId: 'TC7OcDa7JlWbqMaN',
     proficiencyKey: 'med',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'treat-poison',
+    compendiumId: 'KjoCEEmPGTeFE4hh',
     proficiencyKey: 'med',
     requiredRank: 1,
   },
   {
     slug: 'treat-wounds',
+    compendiumId: '1kGNdIIhuglAjIp9',
     proficiencyKey: 'med',
     actionType: '',
     requiredRank: 1,
@@ -270,10 +291,12 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   // Nature
   {
     slug: 'command-an-animal',
+    compendiumId: 'q9nbyIF0PEBqMtYe',
     proficiencyKey: 'nat',
   },
   {
     slug: 'identify-magic',
+    compendiumId: 'eReSHVEPCsdkSL4G',
     key: 'identifyMagicNature',
     proficiencyKey: 'nat',
     actionType: '',
@@ -281,6 +304,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'learn-a-spell',
+    compendiumId: 'Q5iIYCFdqJFM31GW',
     key: 'learnASpellNature',
     proficiencyKey: 'nat',
     actionType: '',
@@ -288,12 +312,13 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'recall-knowledge-nature',
-    translation: 'PF2E.RecallKnowledge.Label',
+    compendiumId: 'eT1jXYvz2YH70Ovp',
     proficiencyKey: 'nat',
   },
   // Occultism
   {
     slug: 'decipher-writing',
+    compendiumId: 'd9gbpiQjChYDYA2L',
     key: 'decipherWritingOccultism',
     proficiencyKey: 'occ',
     actionType: '',
@@ -301,6 +326,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'identify-magic',
+    compendiumId: 'eReSHVEPCsdkSL4G',
     key: 'identifyMagicOccultism',
     proficiencyKey: 'occ',
     actionType: '',
@@ -308,6 +334,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'learn-a-spell',
+    compendiumId: 'Q5iIYCFdqJFM31GW',
     key: 'learnASpellOccultism',
     proficiencyKey: 'occ',
     actionType: '',
@@ -315,12 +342,13 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'recall-knowledge-occultism',
-    translation: 'PF2E.RecallKnowledge.Label',
+    compendiumId: 'B2BpIZFHoF9Kjzpx',
     proficiencyKey: 'occ',
   },
   // Performance
   {
     slug: 'earn-income',
+    compendiumId: 'QyzlsLrqM0EEwd7j',
     key: 'earnIncomePerformance',
     proficiencyKey: 'prf',
     actionType: '',
@@ -328,11 +356,13 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'perform',
+    compendiumId: 'EEDElIyin4z60PXx',
     proficiencyKey: 'prf',
   },
   // Religion
   {
     slug: 'decipher-writing',
+    compendiumId: 'd9gbpiQjChYDYA2L',
     key: 'decipherWritingReligion',
     proficiencyKey: 'rel',
     actionType: '',
@@ -340,6 +370,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'identify-magic',
+    compendiumId: 'eReSHVEPCsdkSL4G',
     key: 'identifyMagicReligion',
     proficiencyKey: 'rel',
     actionType: '',
@@ -347,6 +378,7 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'learn-a-spell',
+    compendiumId: 'Q5iIYCFdqJFM31GW',
     key: 'learnASpellReligion',
     proficiencyKey: 'rel',
     actionType: '',
@@ -354,18 +386,20 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'recall-knowledge-religion',
-    translation: 'PF2E.RecallKnowledge.Label',
+    compendiumId: 'LZgjpWd0pL3vK9Q1',
     proficiencyKey: 'rel',
   },
   // Society
   {
     slug: 'create-forgery',
+    compendiumId: 'ftG89SjTSa9DYDOD',
     proficiencyKey: 'soc',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'decipher-writing',
+    compendiumId: 'd9gbpiQjChYDYA2L',
     key: 'decipherWritingSociety',
     proficiencyKey: 'soc',
     actionType: '',
@@ -373,52 +407,58 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'subsist',
+    compendiumId: '49y9Ec4bDii8pcD3',
     key: 'subsistSociety',
     proficiencyKey: 'soc',
     actionType: '',
   },
   {
     slug: 'recall-knowledge-society',
-    translation: 'PF2E.RecallKnowledge.Label',
+    compendiumId: 'KUfLlXDWTcAWhl8l',
     proficiencyKey: 'soc',
   },
   // Stealth
   {
     slug: 'conceal-an-object',
+    compendiumId: 'qVNVSmsgpKFGk9hV',
     proficiencyKey: 'ste',
   },
   {
     slug: 'hide',
-    translation: 'PF2E.Actions.Hide.Title',
+    compendiumId: 'XMcnh4cSI32tljXa',
     proficiencyKey: 'ste',
     icon: 'zealous-conviction',
   },
   {
     slug: 'sneak',
-    translation: 'PF2E.Actions.Sneak.Title',
+    compendiumId: 'VMozDqMMuK5kpoX4',
     proficiencyKey: 'ste',
     icon: 'invisibility',
   },
   // Survival
   {
     slug: 'cover-tracks',
+    compendiumId: 'SB7cMECVtE06kByk',
     proficiencyKey: 'sur',
     actionType: '',
     requiredRank: 1,
   },
   {
     slug: 'sense-direction',
+    compendiumId: 'fJImDBQfqfjKJOhk',
     proficiencyKey: 'sur',
     actionType: '',
   },
   {
     slug: 'subsist',
+    compendiumId: '49y9Ec4bDii8pcD3',
     key: 'subsistSurvival',
     proficiencyKey: 'sur',
     actionType: '',
   },
   {
     slug: 'track',
+    compendiumId: 'EA5vuSgJfiHH7plD',
     proficiencyKey: 'sur',
     actionType: '',
     requiredRank: 1,
@@ -426,17 +466,19 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   // Thievery
   {
     slug: 'disable-device',
+    compendiumId: 'cYdz2grcOcRt4jk6',
     proficiencyKey: 'thi',
     requiredRank: 1,
     actionType: 'D',
   },
   {
     slug: 'palm-an-object',
+    compendiumId: 'ijZ0DDFpMkWqaShd',
     proficiencyKey: 'thi',
   },
   {
     slug: 'pick-a-lock',
-    translation: 'PF2E.Actions.PickALock.Title',
+    compendiumId: '2EE4aF4SZpYf0R6H',
     proficiencyKey: 'thi',
     requiredRank: 1,
     actionType: 'D',
@@ -444,12 +486,13 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   },
   {
     slug: 'steal',
+    compendiumId: 'RDXXE7wMrSPCLv5k',
     proficiencyKey: 'thi',
   },
   // Feat based
   {
     slug: 'bon-mot',
-    translation: 'PF2E.Actions.BonMot.Title',
+    compendiumId: '0GF2j54roPFIDmXf',
     proficiencyKey: 'dip',
     icon: 'hideous-laughter',
   },

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -1,7 +1,7 @@
 <ol class="actions-list item-list inventory-list directory-list skill-action-list">
   <li class="action-header stroke-header">
     {{> systems/pf2e/templates/actors/partials/images/header_stroke.html}}
-    <h3 class="pf-heading pf-actions">Skill Actions</h3>
+    <h3 class="pf-heading pf-actions">{{localize 'SkillActions.Title'}}</h3>
     <div class="item-controls" style="display: flex; align-items: center">
       <div class="item-control">
         <input name="filter" type="text" placeholder="Filter actions">

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -18,7 +18,7 @@
         <i class="fas fa-comment-alt"></i>
       </div>
       <div class="actions-title">
-        <div class="action-name">
+        <div class="action-name" style="justify-content: space-between">
           <h4>{{label}} <span class="activity-icon">{{actionType}}</span></h4>
           <div class="action-options">
             <a class="item-control item-toggle-equip {{#if visible}}active{{/if}}" title="Toggle action visibility">


### PR DESCRIPTION
Full translations of all actions
Fully fixes https://github.com/jamespdaily/pf2e-sheet-skill-actions/issues/40

To achieve that, we use IDs to access compendium items instead of slugs. Slugs are only used inside this module to match all maps.
Babele, the module that manages translations, will then provide the translated compendium item.
That way, everything is translated, even the text posted in the chat log.

Remove old translation key no longer necessary : we can directly use the label of the compendium item.
Add a hook on babele.ready to reload actions when babele finished its translation work.

Also a bit of style : shirt is now aligned on the right :)

![image](https://user-images.githubusercontent.com/18362479/161769170-2bc486ed-b6a5-48e8-aa9d-4dfd0a2a88dd.png)

