### PR TITLE
Fix the "General Module Settings"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sheet-skill-actions
+# pf2e-sheet-skill-actions
 
 This will add a number of skill actions to your stikes list to be more easily accessible to the player.
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,5 +1,5 @@
 {
-  "SkillActions": {
+  "pf2e-sheet-skill-actions": {
     "Title": "Skill Actions",
     "Settings": {
       "Position": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1,5 +1,5 @@
 {
-  "SkillActions": {
+  "pf2e-sheet-skill-actions": {
     "Title": "Actions de Compétence",
     "Settings": {
       "Position": {

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -1,4 +1,4 @@
-export const SKILLS_ACTIONS_MODULE_NAME = 'SkillActions';
+export const SKILLS_ACTIONS_MODULE_NAME = 'pf2e-sheet-skill-actions';
 
 /**
  * Because typescript doesn't know when in the lifecycle of foundry your code runs, we have to assume that the

--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -19,7 +19,7 @@ import { SkillActionCollection } from './skill-actions';
 
 // Initialize module
 Hooks.once('init', async () => {
-  console.log('sheet-skill-actions | Initializing sheet-skill-actions');
+  console.log('pf2e-sheet-skill-actions | Initializing pf2e-sheet-skill-actions');
 
   // Assign custom classes and constants here
 


### PR DESCRIPTION
I lied; it was easier than I expected. Tested after `npm run build` and seemed to work fine with no issues.

- Places the module's settings in a category of its own, rather than the "General Module Settings"
- Tidy up the README and a console log to more accurately use the module's name

Resolves issue #46.

![image](https://user-images.githubusercontent.com/34202141/162663967-d397fbb6-c57d-4ca7-b6f8-1e6b5207aafc.png)

Thank you 😘
