### PR TITLE
Show unequipped actions in gray

### DIFF
--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -21,8 +21,8 @@
         <div class="action-name" style="justify-content: space-between">
           <h4>{{label}} <span class="activity-icon">{{actionType}}</span></h4>
           <div class="action-options">
-            <a class="item-control item-toggle-equip {{#if visible}}active{{/if}}" title="Toggle action visibility">
-              <i class="fas fa-tshirt"></i>
+            <a class="item-control item-toggle-equip" title="Toggle action visibility">
+              <i class="fas fa-tshirt" {{#unless visible}}style="color: rgba(0, 0, 0, 0.4);"{{/unless}}></i>
             </a>
           </div>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25230/162813187-7092a4e2-0079-46fd-8c6f-d8ffce011da3.png)

Since PF2e removed shirt icon for strikes, our styling was broken for distinguishing equipped/unequipped actions.