### PR TITLE
All click to (un)equip all actions

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -8,6 +8,9 @@
         "top": "Top",
         "bot": "Bottom"
       }
+    },
+    "UnequipAll": {
+      "Tooltip": "Toggle hidden actions. Hold alt when clicking to make unequip/equip all skills."
     }
   }
 }

--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -55,8 +55,9 @@ function renderActionsList(skillActions: SkillActionCollection, actor: Actor) {
   const $skillActions = $(templates[0]({ skills: skillData, allVisible: allVisible }));
   const $items = $skillActions.find('li.item');
 
-  $skillActions.on('click', '.toggle-hidden-actions', function () {
-    Flag.set(actor, 'allVisible', !Flag.get(actor, 'allVisible'));
+  $skillActions.on('click', '.toggle-hidden-actions', function (e) {
+    if (e.altKey) skillActions.toggleVisibility();
+    else Flag.set(actor, 'allVisible', !Flag.get(actor, 'allVisible'));
   });
 
   $skillActions.on('input', 'input[name="filter"]', function (e) {
@@ -77,8 +78,7 @@ function renderActionsList(skillActions: SkillActionCollection, actor: Actor) {
 
   $items.on('click', '.item-toggle-equip', function (e) {
     e.stopPropagation();
-    const action = skillActions.fromEvent(e);
-    action.update({ visible: !action.visible });
+    skillActions.fromEvent(e).toggleVisibility();
   });
 
   $items.on('click', '.action-name', function (e) {

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -93,6 +93,10 @@ export class SkillAction {
     await Flag.set(this.actor, `actions.${this.key}`, data);
   }
 
+  async toggleVisibility(visible = !this.visible) {
+    await this.update({ visible: visible });
+  }
+
   async rollSkillAction(event) {
     if (!(game instanceof Game)) return;
 
@@ -250,5 +254,10 @@ export class SkillActionCollection extends Collection<SkillAction> {
 
   fromEvent(e: JQuery.TriggeredEvent) {
     return this.fromElement(e.delegateTarget);
+  }
+
+  toggleVisibility() {
+    const visible = !this.some((action) => action.visible);
+    this.forEach((action) => action.toggleVisibility(visible));
   }
 }

--- a/src/templates/skill-actions.html
+++ b/src/templates/skill-actions.html
@@ -6,7 +6,7 @@
       <div class="item-control">
         <input name="filter" type="text" placeholder="Filter actions">
       </div>
-      <a class="item-control toggle-hidden-actions" title="Toggle hidden actions">
+      <a class="item-control toggle-hidden-actions" title="{{ localize 'pf2e-sheet-skill-actions.UnequipAll.Tooltip' }}">
         <i class="fas fa-tshirt" {{#if allVisible}}style="color: rgba(0, 0, 0, 0.4);"{{/if}}></i>
       </a>
     </div>


### PR DESCRIPTION
It's a bit janky since it has to unequip them one by one but it works. I used `alt` since it's quite destructive operation, and there's lower chance of `alt` being clicked than others. Fixes #38