### PR TITLE
Implement multiple skills per action

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ I love you.
   * **compendiumID** (required) - ID of the action or feat in the compendium. You can drag and drop the action in a jounal to find the link generated (like @Compendium[pf2e.actionspf2e.S9PZFOVe7zhORkUc]).
   * **proficiencyKey** (required) - 3 letter acronym for the skill in PF2e (`acr`, `arc`, `ath`, `cra`, `dec`, `dip`, `itm`, `med`, `nat`, `occ`, `prf`, `rel`, `soc`, `ste`, `sur`, `thi`)
   * **icon** - name of icon in `[FOUNDRY DATA]/Data/systems/pf2e/icons/spells` to use.
-  * **requiredRank** - add action requires training in skill. 0 - untrained (default), 1 - trained, 2 - expert, 3 - master, 4 - legendary.
   * **actionType** - add if this does not use 1 action. 'A' - 1 action (default), 'D' - 2 actions, 'T' - 3 actions, 'F' - free action, 'R' - reaction.
   * **key** - is used to match action implemented by PF2e. You shouldn't need to specify it.
-  * **variants** - an array of variants to the action in case you want more than one button. MAP variants are added automatically.
+  * **variants** - an array of variants, each of which will create a separate button. MAP & assurance variants are added automatically. Each entry can have:
+    * **proficiencyKey** (required) - 3 letter acronym for the skill in PF2e (`acr`, `arc`, `ath`, `cra`, `dec`, `dip`, `itm`, `med`, `nat`, `occ`, `prf`, `rel`, `soc`, `ste`, `sur`, `thi`)
+    * **label** - a label in case you don't want to use the default "[Skill]"
+    * **requiredRank** - add if variant requires training in skill. 0 - untrained (default), 1 - trained, 2 - expert, 3 - master, 4 - legendary.
+    * **extra** - any extra parameters that are passed to pf2e actions.
 * Click "Propose changes" and "Create pull request".

--- a/src/module/globals.d.ts
+++ b/src/module/globals.d.ts
@@ -20,7 +20,11 @@ export interface ItemTraits extends ValuesList {
 export type Rank = 0 | 1 | 2 | 3 | 4;
 
 interface CharacterSkillData {
+  label?: string;
+  name: string;
   rank: Rank;
+  value: number;
+  modifiers: ModifierPF2e[];
 }
 
 interface BaseActorDataPF2e {

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -1,20 +1,6 @@
-export const SKILLS_ACTIONS_MODULE_NAME = 'pf2e-sheet-skill-actions';
+import { getGame } from './utils';
 
-/**
- * Because typescript doesn't know when in the lifecycle of foundry your code runs, we have to assume that the
- * canvas is potentially not yet initialized, so it's typed as declare let canvas: Canvas | {ready: false}.
- * That's why you get errors when you try to access properties on canvas other than ready.
- * In order to get around that, you need to type guard canvas.
- * Also be aware that this will become even more important in 0.8.x because no canvas mode is being introduced there.
- * So you will need to deal with the fact that there might not be an initialized canvas at any point in time.
- * @returns
- */
-export function getGame(): Game {
-  if (!(game instanceof Game)) {
-    throw new Error('Game Is Not Initialized');
-  }
-  return game;
-}
+export const SKILLS_ACTIONS_MODULE_NAME = 'pf2e-sheet-skill-actions';
 
 export function registerSettings(): void {
   getGame().settings.register(SKILLS_ACTIONS_MODULE_NAME, 'Position', {

--- a/src/module/sheet-skill-actions.ts
+++ b/src/module/sheet-skill-actions.ts
@@ -11,10 +11,10 @@
  */
 
 // Import TypeScript modules
-import { registerSettings, getGame, SKILLS_ACTIONS_MODULE_NAME } from './settings';
+import { registerSettings, SKILLS_ACTIONS_MODULE_NAME } from './settings';
 import { preloadTemplates } from './preloadTemplates';
 import { ActionsIndex } from './actions-index';
-import { Flag } from './utils';
+import { Flag, getGame } from './utils';
 import { SkillActionCollection } from './skill-actions';
 
 let templates: Handlebars.TemplateDelegate[];

--- a/src/module/skill-actions-data.ts
+++ b/src/module/skill-actions-data.ts
@@ -3,11 +3,11 @@ import { Rank } from './globals';
 
 export type ActionType = 'A' | 'D' | 'T' | 'F' | 'R' | '';
 
-interface Variant {
-  label: string;
-  map?: number;
+export interface VariantData {
+  label?: string;
+  proficiencyKey: string;
   extra?: Record<string, unknown>;
-  assurance?: number;
+  requiredRank?: Rank;
 }
 
 export interface SkillActionData {
@@ -15,485 +15,356 @@ export interface SkillActionData {
   slug: string;
   compendiumId: string;
   icon: string;
-  proficiencyKey: string;
-  requiredRank: Rank;
   actionType: ActionType;
-  variants?: () => Variant[];
+  variants: VariantData[];
   actor: Actor;
 }
 
-export type SkillActionDataParameters = PartialBy<
-  SkillActionData,
-  'key' | 'actionType' | 'icon' | 'requiredRank' | 'compendiumId'
->;
+export type SkillActionDataParameters = PartialBy<SkillActionData, 'key' | 'actionType' | 'icon' | 'compendiumId'>;
 
 export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, 'actor'>[] = [
   // Acrobatics
   {
     slug: 'balance',
     compendiumId: 'M76ycLAqHoAgbcej',
-    proficiencyKey: 'acr',
     icon: 'freedom-of-movement',
+    variants: [{ proficiencyKey: 'acr' }],
   },
   {
     slug: 'squeeze',
     compendiumId: 'kMcV8e5EZUxa6evt',
-    proficiencyKey: 'acr',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'acr', requiredRank: 1 }],
   },
   {
     slug: 'tumble-through',
     compendiumId: '21WIfSu7Xd7uKqV8',
-    proficiencyKey: 'acr',
     icon: 'unimpeded-stride',
+    variants: [{ proficiencyKey: 'acr' }],
   },
   {
     slug: 'maneuver-in-flight',
     compendiumId: 'Qf1ylAbdVi1rkc8M',
-    proficiencyKey: 'acr',
-    requiredRank: 1,
     icon: 'fleet-step',
+    variants: [{ proficiencyKey: 'acr', requiredRank: 1 }],
   },
   // Arcana
   {
     slug: 'borrow-an-arcane-spell',
     compendiumId: 'OizxuPb44g3eHPFh',
-    proficiencyKey: 'arc',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'arc', requiredRank: 1 }],
   },
   {
     slug: 'decipher-writing',
     compendiumId: 'd9gbpiQjChYDYA2L',
-    key: 'decipherWritingArcana',
-    proficiencyKey: 'arc',
     actionType: '',
-    requiredRank: 1,
+    variants: [
+      { proficiencyKey: 'arc', requiredRank: 1 },
+      { proficiencyKey: 'occ', requiredRank: 1 },
+      { proficiencyKey: 'rel', requiredRank: 1 },
+      { proficiencyKey: 'soc', requiredRank: 1 },
+    ],
   },
   {
     slug: 'identify-magic',
     compendiumId: 'eReSHVEPCsdkSL4G',
-    key: 'identifyMagicArcana',
-    proficiencyKey: 'arc',
     actionType: '',
-    requiredRank: 1,
+    variants: [
+      { proficiencyKey: 'arc', requiredRank: 1 },
+      { proficiencyKey: 'nat', requiredRank: 1 },
+      { proficiencyKey: 'occ', requiredRank: 1 },
+      { proficiencyKey: 'rel', requiredRank: 1 },
+    ],
   },
   {
     slug: 'learn-a-spell',
     compendiumId: 'Q5iIYCFdqJFM31GW',
-    key: 'learnASpellArcana',
-    proficiencyKey: 'arc',
     actionType: '',
-    requiredRank: 1,
+    variants: [
+      { proficiencyKey: 'arc', requiredRank: 1 },
+      { proficiencyKey: 'nat', requiredRank: 1 },
+      { proficiencyKey: 'occ', requiredRank: 1 },
+      { proficiencyKey: 'rel', requiredRank: 1 },
+    ],
   },
   {
-    slug: 'recall-knowledge-arcana',
-    compendiumId: 'KygTSeDvsFoSO6HW',
-    proficiencyKey: 'arc',
+    slug: 'recall-knowledge-lore',
+    compendiumId: '1OagaWtBpVXExToo',
+    variants: [
+      { proficiencyKey: 'arc' },
+      { proficiencyKey: 'cra' },
+      { proficiencyKey: 'nat' },
+      { proficiencyKey: 'occ' },
+      { proficiencyKey: 'rel' },
+      { proficiencyKey: 'soc' },
+      { proficiencyKey: 'lore' },
+    ],
   },
   // Athletics
   {
     slug: 'climb',
     compendiumId: 'pprgrYQ1QnIDGZiy',
-    proficiencyKey: 'ath',
     icon: 'heroic-feat',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'force-open',
     compendiumId: 'SjmKHgI7a5Z9JzBx',
-    proficiencyKey: 'ath',
     icon: 'indestructibility',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'disarm',
     compendiumId: 'Dt6B1slsBy8ipJu9',
-    proficiencyKey: 'ath',
-    requiredRank: 1,
     icon: 'perfect-strike',
+    variants: [{ proficiencyKey: 'ath', requiredRank: 1 }],
   },
   {
     slug: 'grapple',
     compendiumId: 'PMbdMWc2QroouFGD',
-    proficiencyKey: 'ath',
     icon: 'remove-fear',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'high-jump',
     compendiumId: '2HJ4yuEFY1Cast4h',
-    proficiencyKey: 'ath',
     actionType: 'D',
     icon: 'jump',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'long-jump',
     compendiumId: 'JUvAvruz7yRQXfz2',
-    proficiencyKey: 'ath',
     actionType: 'D',
     icon: 'longstrider',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'shove',
     compendiumId: '7blmbDrQFNfdT731',
-    proficiencyKey: 'ath',
     icon: 'ki-strike',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'swim',
     compendiumId: 'c8TGiZ48ygoSPofx',
-    proficiencyKey: 'ath',
     icon: 'waters-of-prediction',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   {
     slug: 'trip',
     compendiumId: 'ge56Lu1xXVFYUnLP',
-    proficiencyKey: 'ath',
     icon: 'natures-enmity',
+    variants: [{ proficiencyKey: 'ath' }],
   },
   // Crafting
   {
     slug: 'craft',
     compendiumId: 'rmwa3OyhTZ2i2AHl',
-    proficiencyKey: 'cra',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'cra', requiredRank: 1 }],
   },
   {
     slug: 'earn-income',
     compendiumId: 'QyzlsLrqM0EEwd7j',
-    key: 'earnIncomeCrafting',
-    proficiencyKey: 'cra',
     actionType: '',
-    requiredRank: 1,
+    variants: [
+      { proficiencyKey: 'cra', requiredRank: 1 },
+      { proficiencyKey: 'lore', requiredRank: 1 },
+      { proficiencyKey: 'prf', requiredRank: 1 },
+    ],
   },
   {
     slug: 'identify-alchemy',
     compendiumId: 'Q4kdWVOf2ztIBFg1',
-    proficiencyKey: 'cra',
     actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'recall-knowledge-crafting',
-    compendiumId: 'B0Eu3EfwIa9kyDEA',
-    proficiencyKey: 'cra',
+    variants: [{ proficiencyKey: 'cra', requiredRank: 1 }],
   },
   {
     slug: 'repair',
     compendiumId: 'bT3skovyLUtP22ME',
-    proficiencyKey: 'cra',
     actionType: '',
+    variants: [{ proficiencyKey: 'cra' }],
   },
   // Deception
   {
     slug: 'create-a-diversion',
     compendiumId: 'GkmbTGfg8KcgynOA',
-    proficiencyKey: 'dec',
-    variants: function () {
-      return [
-        { label: 'Distracting Words', extra: { variant: 'distracting-words' } },
-        { label: 'Gesture', extra: { variant: 'gesture' } },
-        { label: 'Trick', extra: { variant: 'trick' } },
-      ];
-    },
+    variants: [
+      { label: 'Distracting Words', proficiencyKey: 'dec', extra: { variant: 'distracting-words' } },
+      { label: 'Gesture', proficiencyKey: 'dec', extra: { variant: 'gesture' } },
+      { label: 'Trick', proficiencyKey: 'dec', extra: { variant: 'trick' } },
+    ],
   },
   {
     slug: 'feint',
     compendiumId: 'QNAVeNKtHA0EUw4X',
-    proficiencyKey: 'dec',
-    requiredRank: 1,
     icon: 'delay-consequence',
+    variants: [{ proficiencyKey: 'dec', requiredRank: 1 }],
   },
   {
     slug: 'impersonate',
     compendiumId: 'AJstokjdG6iDjVjE',
-    proficiencyKey: 'dec',
     actionType: '',
+    variants: [{ proficiencyKey: 'dec' }],
   },
   {
     slug: 'lie',
     compendiumId: 'ewwCglB7XOPLUz72',
-    proficiencyKey: 'dec',
     actionType: '',
+    variants: [{ proficiencyKey: 'dec' }],
   },
   // Diplomacy
   {
     slug: 'gather-information',
     compendiumId: 'plBGdZhqq5JBl1D8',
-    proficiencyKey: 'dip',
     actionType: '',
+    variants: [{ proficiencyKey: 'dip' }],
   },
   {
     slug: 'make-an-impression',
     compendiumId: 'OX4fy22hQgUHDr0q',
-    proficiencyKey: 'dip',
     actionType: '',
+    variants: [{ proficiencyKey: 'dip' }],
   },
   {
     slug: 'request',
     compendiumId: 'DCb62iCBrJXy0Ik6',
-    proficiencyKey: 'dip',
     icon: 'cackle',
+    variants: [{ proficiencyKey: 'dip' }],
   },
   // Intimidation
   {
     slug: 'coerce',
     compendiumId: 'tHCqgwjtQtzNqVvd',
-    proficiencyKey: 'itm',
     actionType: '',
+    variants: [{ proficiencyKey: 'itm' }],
   },
   {
     slug: 'demoralize',
     compendiumId: '2u915NdUyQan6uKF',
-    proficiencyKey: 'itm',
     icon: 'blind-ambition',
+    variants: [{ proficiencyKey: 'itm' }],
   },
   // Lore
-  {
-    slug: 'earn-income',
-    compendiumId: 'QyzlsLrqM0EEwd7j',
-    proficiencyKey: 'lore',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'recall-knowledge-lore',
-    compendiumId: '1OagaWtBpVXExToo',
-    proficiencyKey: 'lore',
-  },
   // Medicine
   {
     slug: 'administer-first-aid',
     compendiumId: 'MHLuKy4nQO2Z4Am1',
-    proficiencyKey: 'med',
     actionType: 'D',
+    variants: [{ proficiencyKey: 'med' }],
   },
   {
     slug: 'treat-disease',
     compendiumId: 'TC7OcDa7JlWbqMaN',
-    proficiencyKey: 'med',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'med', requiredRank: 1 }],
   },
   {
     slug: 'treat-poison',
     compendiumId: 'KjoCEEmPGTeFE4hh',
-    proficiencyKey: 'med',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'med', requiredRank: 1 }],
   },
   {
     slug: 'treat-wounds',
     compendiumId: '1kGNdIIhuglAjIp9',
-    proficiencyKey: 'med',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'med', requiredRank: 1 }],
   },
   // Nature
   {
     slug: 'command-an-animal',
     compendiumId: 'q9nbyIF0PEBqMtYe',
-    proficiencyKey: 'nat',
-  },
-  {
-    slug: 'identify-magic',
-    compendiumId: 'eReSHVEPCsdkSL4G',
-    key: 'identifyMagicNature',
-    proficiencyKey: 'nat',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'learn-a-spell',
-    compendiumId: 'Q5iIYCFdqJFM31GW',
-    key: 'learnASpellNature',
-    proficiencyKey: 'nat',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'recall-knowledge-nature',
-    compendiumId: 'eT1jXYvz2YH70Ovp',
-    proficiencyKey: 'nat',
+    variants: [{ proficiencyKey: 'nat' }],
   },
   // Occultism
-  {
-    slug: 'decipher-writing',
-    compendiumId: 'd9gbpiQjChYDYA2L',
-    key: 'decipherWritingOccultism',
-    proficiencyKey: 'occ',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'identify-magic',
-    compendiumId: 'eReSHVEPCsdkSL4G',
-    key: 'identifyMagicOccultism',
-    proficiencyKey: 'occ',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'learn-a-spell',
-    compendiumId: 'Q5iIYCFdqJFM31GW',
-    key: 'learnASpellOccultism',
-    proficiencyKey: 'occ',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'recall-knowledge-occultism',
-    compendiumId: 'B2BpIZFHoF9Kjzpx',
-    proficiencyKey: 'occ',
-  },
   // Performance
-  {
-    slug: 'earn-income',
-    compendiumId: 'QyzlsLrqM0EEwd7j',
-    key: 'earnIncomePerformance',
-    proficiencyKey: 'prf',
-    actionType: '',
-    requiredRank: 1,
-  },
   {
     slug: 'perform',
     compendiumId: 'EEDElIyin4z60PXx',
-    proficiencyKey: 'prf',
+    variants: [{ proficiencyKey: 'prf' }],
   },
   // Religion
-  {
-    slug: 'decipher-writing',
-    compendiumId: 'd9gbpiQjChYDYA2L',
-    key: 'decipherWritingReligion',
-    proficiencyKey: 'rel',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'identify-magic',
-    compendiumId: 'eReSHVEPCsdkSL4G',
-    key: 'identifyMagicReligion',
-    proficiencyKey: 'rel',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'learn-a-spell',
-    compendiumId: 'Q5iIYCFdqJFM31GW',
-    key: 'learnASpellReligion',
-    proficiencyKey: 'rel',
-    actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'recall-knowledge-religion',
-    compendiumId: 'LZgjpWd0pL3vK9Q1',
-    proficiencyKey: 'rel',
-  },
   // Society
   {
     slug: 'create-forgery',
     compendiumId: 'ftG89SjTSa9DYDOD',
-    proficiencyKey: 'soc',
     actionType: '',
-    requiredRank: 1,
-  },
-  {
-    slug: 'decipher-writing',
-    compendiumId: 'd9gbpiQjChYDYA2L',
-    key: 'decipherWritingSociety',
-    proficiencyKey: 'soc',
-    actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'soc', requiredRank: 1 }],
   },
   {
     slug: 'subsist',
     compendiumId: '49y9Ec4bDii8pcD3',
-    key: 'subsistSociety',
-    proficiencyKey: 'soc',
     actionType: '',
-  },
-  {
-    slug: 'recall-knowledge-society',
-    compendiumId: 'KUfLlXDWTcAWhl8l',
-    proficiencyKey: 'soc',
+    variants: [{ proficiencyKey: 'soc' }, { proficiencyKey: 'sur' }],
   },
   // Stealth
   {
     slug: 'conceal-an-object',
     compendiumId: 'qVNVSmsgpKFGk9hV',
-    proficiencyKey: 'ste',
+    variants: [{ proficiencyKey: 'ste' }],
   },
   {
     slug: 'hide',
     compendiumId: 'XMcnh4cSI32tljXa',
-    proficiencyKey: 'ste',
     icon: 'zealous-conviction',
+    variants: [{ proficiencyKey: 'ste' }],
   },
   {
     slug: 'sneak',
     compendiumId: 'VMozDqMMuK5kpoX4',
-    proficiencyKey: 'ste',
     icon: 'invisibility',
+    variants: [{ proficiencyKey: 'ste' }],
   },
   // Survival
   {
     slug: 'cover-tracks',
     compendiumId: 'SB7cMECVtE06kByk',
-    proficiencyKey: 'sur',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'sur', requiredRank: 1 }],
   },
   {
     slug: 'sense-direction',
     compendiumId: 'fJImDBQfqfjKJOhk',
-    proficiencyKey: 'sur',
     actionType: '',
-  },
-  {
-    slug: 'subsist',
-    compendiumId: '49y9Ec4bDii8pcD3',
-    key: 'subsistSurvival',
-    proficiencyKey: 'sur',
-    actionType: '',
+    variants: [{ proficiencyKey: 'sur' }],
   },
   {
     slug: 'track',
     compendiumId: 'EA5vuSgJfiHH7plD',
-    proficiencyKey: 'sur',
     actionType: '',
-    requiredRank: 1,
+    variants: [{ proficiencyKey: 'sur', requiredRank: 1 }],
   },
   // Thievery
   {
     slug: 'disable-device',
     compendiumId: 'cYdz2grcOcRt4jk6',
-    proficiencyKey: 'thi',
-    requiredRank: 1,
     actionType: 'D',
+    variants: [{ proficiencyKey: 'thi', requiredRank: 1 }],
   },
   {
     slug: 'palm-an-object',
     compendiumId: 'ijZ0DDFpMkWqaShd',
-    proficiencyKey: 'thi',
+    variants: [{ proficiencyKey: 'thi' }],
   },
   {
     slug: 'pick-a-lock',
     compendiumId: '2EE4aF4SZpYf0R6H',
-    proficiencyKey: 'thi',
-    requiredRank: 1,
     actionType: 'D',
     icon: 'ward-domain',
+    variants: [{ proficiencyKey: 'thi', requiredRank: 1 }],
   },
   {
     slug: 'steal',
     compendiumId: 'RDXXE7wMrSPCLv5k',
-    proficiencyKey: 'thi',
+    variants: [{ proficiencyKey: 'thi' }],
   },
   // Feat based
   {
     slug: 'bon-mot',
     compendiumId: '0GF2j54roPFIDmXf',
-    proficiencyKey: 'dip',
     icon: 'hideous-laughter',
+    variants: [{ proficiencyKey: 'dip' }],
   },
 ];

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -14,3 +14,19 @@ export const Flag = {
 export function camelize(value: string): string {
   return value.replace(/-(\w)/g, (_, letter) => letter.toUpperCase());
 }
+
+/**
+ * Because typescript doesn't know when in the lifecycle of foundry your code runs, we have to assume that the
+ * canvas is potentially not yet initialized, so it's typed as declare let canvas: Canvas | {ready: false}.
+ * That's why you get errors when you try to access properties on canvas other than ready.
+ * In order to get around that, you need to type guard canvas.
+ * Also be aware that this will become even more important in 0.8.x because no canvas mode is being introduced there.
+ * So you will need to deal with the fact that there might not be an initialized canvas at any point in time.
+ * @returns
+ */
+export function getGame(): Game {
+  if (!(game instanceof Game)) {
+    throw new Error('game is not initialized yet!');
+  }
+  return game;
+}

--- a/src/module/variants.ts
+++ b/src/module/variants.ts
@@ -1,0 +1,55 @@
+import { CharacterSkillData } from './globals';
+import { ModifierPF2e } from './pf2e';
+import { getGame } from './utils';
+
+export class VariantsCollection extends Array<Variant> {
+  addBasicVariant(skill: CharacterSkillData, extra: Record<string, unknown> | undefined, label: string | undefined) {
+    const modifier = (skill.value >= 0 ? ' +' : ' ') + skill.value;
+    label ??= skill.label ? getGame().i18n.localize(skill.label) : skill.name;
+
+    this.push(new Variant(`${label}${modifier}`, skill, extra));
+  }
+
+  addMapVariant(skill: CharacterSkillData, extra: Record<string, unknown> | undefined, map: number) {
+    const modifier = new ModifierPF2e({
+      label: getGame().i18n.localize('PF2E.MultipleAttackPenalty'),
+      modifier: map,
+      type: 'untyped',
+    });
+    const label = getGame().i18n.format('PF2E.MAPAbbreviationLabel', { penalty: map });
+    this.push(new Variant(label, skill, extra, [modifier]));
+  }
+
+  addAssuranceVariant(skill: CharacterSkillData, extra: Record<string, unknown> | undefined) {
+    const proficiency = skill.modifiers.find((m) => m.type === 'proficiency');
+    const assuranceTotal = 10 + (proficiency?.modifier || 0);
+    //Assurance has no i18n translation in system
+    this.push(new Variant('Assurance : ' + assuranceTotal, skill, extra, [], assuranceTotal));
+  }
+
+  matchFilter(filter: string) {
+    return this.some((variant) => variant.label.toLowerCase().includes(filter));
+  }
+}
+
+export class Variant {
+  label: string;
+  skill: CharacterSkillData;
+  extra?: Record<string, unknown>;
+  modifiers: ModifierPF2e[];
+  assuranceTotal: number;
+
+  constructor(
+    label: string,
+    skill: CharacterSkillData,
+    extra: Record<string, unknown> | undefined,
+    modifiers: ModifierPF2e[] = [],
+    assuranceTotal = 0,
+  ) {
+    this.label = label;
+    this.skill = skill;
+    this.extra = extra;
+    this.modifiers = modifiers;
+    this.assuranceTotal = assuranceTotal;
+  }
+}


### PR DESCRIPTION
Actions now list all skills that can be rolled instead of using separate action for each skill, with each skill listing normal roll first, then MAP rolls (if needed) and then assurance rolls (if available):
![image](https://user-images.githubusercontent.com/25230/166105172-d9cf2b28-c23f-4cc9-b90f-88db447a62c6.png)

If action requires you to be trained in a skill, it checks separately per skill, e.g. someone who's trained in war lore, performance & crafting sees:
![image](https://user-images.githubusercontent.com/25230/166105224-e7485b54-74e9-4f3c-b673-fd65588d1c31.png)

While someone who's only trained in crafting sees:
![image](https://user-images.githubusercontent.com/25230/166105248-8c78e844-a26e-44fa-a78f-537a44092ae2.png)

And you can still filter by skill:
![image](https://user-images.githubusercontent.com/25230/166105259-1d8f0eb9-2f2d-4448-b889-311eb570938a.png)

Closes #48 