### PR TITLE
Remove calling of no-longer-present ItemPF2e#calculateMap

### DIFF
--- a/src/module/globals.d.ts
+++ b/src/module/globals.d.ts
@@ -46,7 +46,6 @@ interface BaseItemSourcePF2e {
 export class ItemPF2e extends Item {
   slug: string | null;
   toChat(event?: JQuery.TriggeredEvent): Promise<undefined>;
-  calculateMap(): { label: string; map2: number; map3: number };
 }
 
 export type ItemConstructor = new (

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -184,9 +184,8 @@ export class SkillAction {
       this.variants.addBasicVariant(skill, data.extra, data.label);
 
       if (this.hasTrait('attack')) {
-        const map = this.pf2eItem.calculateMap();
-        this.variants.addMapVariant(skill, data.extra, map.map2);
-        this.variants.addMapVariant(skill, data.extra, map.map3);
+        this.variants.addMapVariant(skill, data.extra, -5);
+        this.variants.addMapVariant(skill, data.extra, -10);
       }
 
       if (this.actorHasItem('assurance-' + skill.name)) {


### PR DESCRIPTION
This method has been removed from the system. The penalty values can be hard-coded for the purpose of this module since only attack rolls benefit from the agile trait.