### PR TITLE
Add new setting to select icon type

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -7,6 +7,12 @@
         "hint": "Position in the skill page; Top : right after Strikes, Bottom : At the end",
         "top": "Top",
         "bot": "Bottom"
+      },
+      "IconStyle": {
+        "name": "Icon Style",
+        "hint": "Icon style on the skill; Action Cost Icon: For the actions cost icon, Skill Icon: For the skills icon if it's available",
+        "actionCostIcon": "Action Cost Icon",
+        "skillIcon": "Skill Icon"
       }
     },
     "UnequipAll": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -7,6 +7,12 @@
         "hint": "Position dans la page des actions; Haut : juste après les frappes, Bas : en dernière position.",
         "top": "Haut",
         "bot": "Bas"
+      },
+      "IconStyle": {
+        "name": "Style d'icône",
+        "hint": "Style d'icône sur la compétence; Icône Coût de l'action: pour l'icône du coût des actions, Icône de compétence: pour l'icône des compétences si elle est disponible",
+        "actionCostIcon": "Icône Coût de l'action",
+        "skillIcon": "Icône de compétence"
       }
     }
   }

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -15,4 +15,16 @@ export function registerSettings(): void {
       bot: `${SKILLS_ACTIONS_MODULE_NAME}.Settings.Position.bot`,
     },
   });
+  getGame().settings.register(SKILLS_ACTIONS_MODULE_NAME, 'IconStyle', {
+    name: `${SKILLS_ACTIONS_MODULE_NAME}.Settings.IconStyle.name`,
+    hint: `${SKILLS_ACTIONS_MODULE_NAME}.Settings.IconStyle.hint`,
+    scope: 'client',
+    config: true,
+    default: 'top',
+    type: String,
+    choices: {
+      actionCostIcon: `${SKILLS_ACTIONS_MODULE_NAME}.Settings.IconStyle.actionCostIcon`,
+      skillIcon: `${SKILLS_ACTIONS_MODULE_NAME}.Settings.IconStyle.skillIcon`,
+    },
+  });
 }

--- a/src/module/skill-actions.ts
+++ b/src/module/skill-actions.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 
+import { SKILLS_ACTIONS_MODULE_NAME } from './settings';
 import { ActionsIndex } from './actions-index';
 import { camelize, Flag, getGame } from './utils';
 import { ActionType, SKILL_ACTIONS_DATA, SkillActionData, SkillActionDataParameters } from './skill-actions-data';
@@ -26,8 +27,18 @@ export class SkillAction {
   constructor(data: SkillActionDataParameters) {
     data.key ??= camelize(data.slug);
     data.actionType ??= 'A';
-    if (data.icon) data.icon = 'systems/pf2e/icons/spells/' + data.icon + '.webp';
-    else data.icon = 'systems/pf2e/icons/actions/' + ACTION_ICONS[data.actionType] + '.webp';
+    switch (getGame().settings.get(SKILLS_ACTIONS_MODULE_NAME, 'IconStyle')) {
+      case 'actionCostIcon': {
+        data.icon = 'systems/pf2e/icons/actions/' + ACTION_ICONS[data.actionType] + '.webp';
+        data.actionType = ''
+        break;
+      }
+      default: {
+        if (data.icon) data.icon = 'systems/pf2e/icons/spells/' + data.icon + '.webp';
+        else data.icon = 'systems/pf2e/icons/actions/' + ACTION_ICONS[data.actionType] + '.webp';
+        break;
+      }
+    }
     this.data = data;
 
     this.variants = new VariantsCollection();


### PR DESCRIPTION
The purpose of this PR is:

To add a new setting to allow user to choose between:

A) Existing behaviour of showing skill icon if available, else showing action cost icon

OR

B) New behaviour of always showing action cost icon, and removing action cost icon from the "activity-icon" span via setting the actionType to ' ' (passive)

The reason for this is that I believe it looks nicer to not have a mix of action cost icons and skill icons as is currently the case. Hence I've added an option to the settings for the users to toggle between the existing behaviour and my proposed behaviour of always just showing the action cost icon (which will then make the icon rendered in the activity-icon span pointless, so I've also added code to "hide" that when the user selects the new setting)

